### PR TITLE
fix: check peers certificate when using https transport

### DIFF
--- a/src/HTTP.cxx
+++ b/src/HTTP.cxx
@@ -77,7 +77,6 @@ void HTTP::initCurl(const std::string &url)
   }
   writeHandle = curl_easy_init();
   curl_easy_setopt(writeHandle, CURLOPT_URL, writeUrl.c_str());
-  curl_easy_setopt(writeHandle, CURLOPT_SSL_VERIFYPEER, 0);
   curl_easy_setopt(writeHandle, CURLOPT_CONNECTTIMEOUT, 10);
   curl_easy_setopt(writeHandle, CURLOPT_TIMEOUT, 10);
   curl_easy_setopt(writeHandle, CURLOPT_POST, 1);
@@ -97,7 +96,6 @@ void HTTP::initCurlRead(const std::string &url)
   mReadUrl = url + "&q=";
   mReadUrl.insert(mReadUrl.find('?'), "/query");
   readHandle = curl_easy_init();
-  curl_easy_setopt(readHandle, CURLOPT_SSL_VERIFYPEER, 0);
   curl_easy_setopt(readHandle, CURLOPT_CONNECTTIMEOUT, 10);
   curl_easy_setopt(readHandle, CURLOPT_TIMEOUT, 10);
   curl_easy_setopt(readHandle, CURLOPT_TCP_KEEPIDLE, 120L);
@@ -126,12 +124,6 @@ void HTTP::enableBasicAuth(const std::string &auth)
   curl_easy_setopt(writeHandle, CURLOPT_USERPWD, auth.c_str());
   curl_easy_setopt(readHandle, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
   curl_easy_setopt(readHandle, CURLOPT_USERPWD, auth.c_str());
-}
-
-void HTTP::enableSsl()
-{
-  curl_easy_setopt(readHandle, CURLOPT_SSL_VERIFYPEER, 0L);
-  curl_easy_setopt(writeHandle, CURLOPT_SSL_VERIFYPEER, 0L);
 }
 
 void HTTP::send(std::string &&lineprotocol)
@@ -206,7 +198,6 @@ void HTTP::createDatabase()
 
   CURL *createHandle = curl_easy_init();
   curl_easy_setopt(createHandle, CURLOPT_URL, createUrl.c_str());
-  curl_easy_setopt(createHandle, CURLOPT_SSL_VERIFYPEER, 0);
   curl_easy_setopt(createHandle, CURLOPT_CONNECTTIMEOUT, 10);
   curl_easy_setopt(createHandle, CURLOPT_TIMEOUT, 10);
   curl_easy_setopt(createHandle, CURLOPT_POST, 1);

--- a/src/HTTP.h
+++ b/src/HTTP.h
@@ -61,9 +61,6 @@ public:
   /// \param auth <username>:<password>
   void enableBasicAuth(const std::string &auth);
 
-  /// Enable SSL
-  void enableSsl();
-
   /// Get the database name managed by this transport
   [[nodiscard]] std::string databaseName() const;
 

--- a/src/InfluxDBFactory.cxx
+++ b/src/InfluxDBFactory.cxx
@@ -72,11 +72,6 @@ std::unique_ptr<Transport> withHttpTransport(const http::url &uri)
   {
     transport->enableBasicAuth(uri.user + ":" + uri.password);
   }
-
-  if (uri.protocol == "https")
-  {
-    transport->enableSsl();
-  }
   return transport;
 }
 


### PR DESCRIPTION
Previously, the peers certificate identity was not checked.
By that, man-in-the-middle attacks where possible by using
self signed certificates.

The fix removes the `CURLOPT_SSL_VERIFYPEER=0` configuration,
so that the CURL default is used and the certificate is properly
checked.

closes #42 