### PR TITLE
fix: conan create package

### DIFF
--- a/conan/CMakeLists.txt
+++ b/conan/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.12.0)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+include(${CMAKE_SOURCE_DIR}/CMakeListsOriginal.txt)

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,5 +1,6 @@
 import re
 import os
+import shutil
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 
@@ -12,7 +13,7 @@ class InfluxdbCxxConan(ConanFile):
     description = "InfluxDB C++ client library."
     topics = ("influxdb", "influxdb-client")
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake_find_package"
+    generators = "cmake"
     options = {"shared": [True, False],
                "tests": [True, False],
                "boost": [True, False]}
@@ -23,7 +24,7 @@ class InfluxdbCxxConan(ConanFile):
                        "libcurl:with_openssl": True,
                        "libcurl:shared": True}
     exports = ["LICENSE"]
-    exports_sources = ("CMakeLists.txt", "src/*", "include/*", "test/*", "cmake/*")
+    exports_sources = ("CMakeLists.txt", "src/*", "include/*", "test/*", "cmake/*", "conan/CMakeLists.txt")
     requires = (
         "libcurl/7.72.0"
     )
@@ -48,6 +49,11 @@ class InfluxdbCxxConan(ConanFile):
     def requirements(self):
         if self.options.boost:
             self.requires("boost/1.74.0")
+
+    def source(self):
+        # Wrap the original CMake file to call conan_basic_setup
+        shutil.move("CMakeLists.txt", "CMakeListsOriginal.txt")
+        shutil.move(os.path.join("conan", "CMakeLists.txt"), "CMakeLists.txt")
 
     def build(self):
         cmake = self._configure_cmake()

--- a/conanfile.py
+++ b/conanfile.py
@@ -12,6 +12,7 @@ class InfluxdbCxxConan(ConanFile):
     description = "InfluxDB C++ client library."
     topics = ("influxdb", "influxdb-client")
     settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake_find_package"
     options = {"shared": [True, False],
                "tests": [True, False],
                "boost": [True, False]}


### PR DESCRIPTION
Creating the package with conan failed because the cmake finder couln't find CURL.
`conan create . influxdb-cxx/0.6.4@steiner/testing -o shared=True -o libcurl:shared=True -o openssl:shared=True -o zlib:shared=True -o boost=False`
```
CMake Error at /usr/share/cmake-3.18/Modules/FindPackageHandleStandardArgs.cmake:165 (message):
  Could NOT find CURL (missing: CURL_LIBRARY CURL_INCLUDE_DIR)
Call Stack (most recent call first):
  /usr/share/cmake-3.18/Modules/FindPackageHandleStandardArgs.cmake:458 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake-3.18/Modules/FindCURL.cmake:169 (find_package_handle_standard_args)
  CMakeLists.txt:74 (find_package)


-- Configuring incomplete, errors occurred!
```
We can use the [cmake_find_package generator](https://blog.conan.io/2018/06/11/Transparent-CMake-Integration.html) here and conan create will work.