### PR TITLE
fix: memory leak in HTTP::query

### DIFF
--- a/src/HTTP.cxx
+++ b/src/HTTP.cxx
@@ -135,6 +135,7 @@ std::string HTTP::query(const std::string &query)
   std::string buffer;
   char* encodedQuery = curl_easy_escape(readHandle, query.c_str(), static_cast<int>(query.size()));
   auto fullUrl = mReadUrl + std::string(encodedQuery);
+  curl_free(encodedQuery);
   curl_easy_setopt(readHandle, CURLOPT_URL, fullUrl.c_str());
   curl_easy_setopt(readHandle, CURLOPT_WRITEDATA, &buffer);
   response = curl_easy_perform(readHandle);


### PR DESCRIPTION
This PR frees the memory that is allocated by `curl_easy_escape`. After fixing, the only remaining blocks are from NSS (`gethostaddr`), where we cannot do much about.

## Before

```
valgrind --leak-check=full ./test/testHttp
==54763== Memcheck, a memory error detector
==54763== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==54763== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==54763== Command: ./test/testHttp
==54763== 
Running 9 test cases...

*** No errors detected
==54763== 
==54763== HEAP SUMMARY:
==54763==     in use at exit: 3,514 bytes in 10 blocks
==54763==   total heap usage: 14,329 allocs, 14,319 frees, 1,868,483 bytes allocated
==54763== 
==54763== 52 bytes in 1 blocks are definitely lost in loss record 1 of 6
==54763==    at 0x483DFAF: realloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==54763==    by 0x4F306D6: ??? (in /usr/lib/x86_64-linux-gnu/libcurl.so.4.6.0)
==54763==    by 0x4F191F9: curl_easy_escape (in /usr/lib/x86_64-linux-gnu/libcurl.so.4.6.0)
==54763==    by 0x4937911: influxdb::transports::HTTP::query(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (HTTP.cxx:136)
==54763==    by 0x14C4CA: _ZZN8influxdb4test14queryUrlFormat11test_methodEvENKUlRKT_E_clIA30_cEEDaS4_ (testHttp.cxx:122)
==54763==    by 0x14C7A8: influxdb::test::queryUrlFormat::test_method() (testHttp.cxx:125)
==54763==    by 0x14C157: influxdb::test::queryUrlFormat_invoker() (testHttp.cxx:118)
==54763==    by 0x1B8F83: boost::detail::function::void_function_invoker0<void (*)(), void>::invoke(boost::detail::function::function_buffer&) (function_template.hpp:117)
==54763==    by 0x17647A: boost::function0<void>::operator()() const (function_template.hpp:763)
==54763==    by 0x16B4CC: boost::detail::forward::operator()() (execution_monitor.ipp:1368)
==54763==    by 0x1B4D34: boost::detail::function::function_obj_invoker0<boost::detail::forward, int>::invoke(boost::detail::function::function_buffer&) (function_template.hpp:137)
==54763==    by 0x193ABE: boost::function0<int>::operator()() const (function_template.hpp:763)
==54763== 
==54763== 52 bytes in 1 blocks are definitely lost in loss record 2 of 6
==54763==    at 0x483DFAF: realloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==54763==    by 0x4F306D6: ??? (in /usr/lib/x86_64-linux-gnu/libcurl.so.4.6.0)
==54763==    by 0x4F191F9: curl_easy_escape (in /usr/lib/x86_64-linux-gnu/libcurl.so.4.6.0)
==54763==    by 0x4937911: influxdb::transports::HTTP::query(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (HTTP.cxx:136)
==54763==    by 0x14C68A: _ZZN8influxdb4test14queryUrlFormat11test_methodEvENKUlRKT_E_clIA31_cEEDaS4_ (testHttp.cxx:122)
==54763==    by 0x14C8B0: influxdb::test::queryUrlFormat::test_method() (testHttp.cxx:126)
==54763==    by 0x14C157: influxdb::test::queryUrlFormat_invoker() (testHttp.cxx:118)
==54763==    by 0x1B8F83: boost::detail::function::void_function_invoker0<void (*)(), void>::invoke(boost::detail::function::function_buffer&) (function_template.hpp:117)
==54763==    by 0x17647A: boost::function0<void>::operator()() const (function_template.hpp:763)
==54763==    by 0x16B4CC: boost::detail::forward::operator()() (execution_monitor.ipp:1368)
==54763==    by 0x1B4D34: boost::detail::function::function_obj_invoker0<boost::detail::forward, int>::invoke(boost::detail::function::function_buffer&) (function_template.hpp:137)
==54763==    by 0x193ABE: boost::function0<int>::operator()() const (function_template.hpp:763)
==54763== 
==54763== LEAK SUMMARY:
==54763==    definitely lost: 104 bytes in 2 blocks
==54763==    indirectly lost: 0 bytes in 0 blocks
==54763==      possibly lost: 0 bytes in 0 blocks
==54763==    still reachable: 3,410 bytes in 8 blocks
==54763==         suppressed: 0 bytes in 0 blocks
==54763== Reachable blocks (those to which a pointer was found) are not shown.
==54763== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==54763== 
==54763== For lists of detected and suppressed errors, rerun with: -s
==54763== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)

```

## After

```
valgrind --leak-check=full ./testHttp
==54424== Memcheck, a memory error detector
==54424== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==54424== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==54424== Command: ./testHttp
==54424== 
Running 9 test cases...

*** No errors detected
==54424== 
==54424== HEAP SUMMARY:
==54424==     in use at exit: 3,410 bytes in 8 blocks
==54424==   total heap usage: 14,182 allocs, 14,174 frees, 2,200,512 bytes allocated
==54424== 
==54424== LEAK SUMMARY:
==54424==    definitely lost: 0 bytes in 0 blocks
==54424==    indirectly lost: 0 bytes in 0 blocks
==54424==      possibly lost: 0 bytes in 0 blocks
==54424==    still reachable: 3,410 bytes in 8 blocks
==54424==         suppressed: 0 bytes in 0 blocks
==54424== Reachable blocks (those to which a pointer was found) are not shown.
==54424== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==54424== 
==54424== For lists of detected and suppressed errors, rerun with: -s
==54424== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```