### PR TITLE
Execute tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,14 @@ jobs:
       - name: update package list
         run: apt-get update
       - name: Install dependencies
-        run: apt-get install -y libcurl4-openssl-dev
+        run: apt-get install -y libcurl4-openssl-dev influxdb
       - name: Install Boost
         if: ${{ matrix.boost == true }}
         run: apt-get install -y libboost-system1.71-dev libboost-test1.71-dev libboost-program-options1.71-dev
       - name: Build
-        run: script/ci_build.sh
+        run: script/ci_build.sh -DINFLUXCXX_TESTING=ON
+      - name: Test
+        run: script/ci_test.sh
       - name: Install
         run: cmake --build build --target install
 

--- a/script/ci_test.sh
+++ b/script/ci_test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -ex
+cd build
+
+# start influxdb
+influxd &
+INFLUX_PID=$!
+sleep 10
+
+# execute tests
+ctest
+
+# stop influx
+kill $INFLUX_PID

--- a/test/testHttp.cxx
+++ b/test/testHttp.cxx
@@ -48,6 +48,7 @@ int getRandomNumber()
 BOOST_AUTO_TEST_CASE(write1)
 {
   auto influxdb = influxdb::InfluxDBFactory::Get("http://localhost:8086?db=test");
+  influxdb->createDatabaseIfNotExists();
   influxdb->write(Point{"test"}
     .addField("value", 10)
     .addTag("host", "localhost"));


### PR DESCRIPTION
... another backport of my `feat/api2` attempts.

(tests are only executed in boost builds, as we use boost-testing)