### PR TITLE
export only public interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,10 @@ endif()
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+# We explicitly export the public interface
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+include(GenerateExportHeader)
 
 # Set fPIC for all targets
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -128,6 +132,7 @@ write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/cmake/InfluxDBConf
 
 # Install headers
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(FILES ${PROJECT_BINARY_DIR}/src/influxdb_export.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 # Export targets
 install(EXPORT InfluxDBTargets

--- a/cmake/InfluxDBConfig.cmake.in
+++ b/cmake/InfluxDBConfig.cmake.in
@@ -7,9 +7,10 @@ get_filename_component(InfluxDB_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 include(CMakeFindDependencyMacro)
 
 if(InfluxDB_WITH_BOOST)
-  find_dependency(Boost)
+  find_dependency(Boost COMPONENTS system REQUIRED)
 endif()
-find_dependency(CURL)
+find_dependency(CURL REQUIRED)
+find_dependency(Threads REQUIRED)
 
 if(NOT TARGET InfluxData::InfluxDB)
   include("${InfluxDB_CMAKE_DIR}/InfluxDBTargets.cmake")

--- a/include/InfluxDB.h
+++ b/include/InfluxDB.h
@@ -35,11 +35,12 @@
 
 #include "Transport.h"
 #include "Point.h"
+#include "influxdb_export.h"
 
 namespace influxdb
 {
 
-class InfluxDB
+class INFLUXDB_EXPORT InfluxDB
 {
   public:
     /// Disable copy constructor

--- a/include/InfluxDBException.h
+++ b/include/InfluxDBException.h
@@ -30,9 +30,11 @@
 #include <stdexcept>
 #include <string>
 
+#include "influxdb_export.h"
+
 namespace influxdb {
 
-class InfluxDBException : public std::runtime_error {
+class INFLUXDB_EXPORT InfluxDBException : public std::runtime_error {
 public:
   InfluxDBException(const std::string &source, const std::string &message) : std::runtime_error::runtime_error(
           "influx-cxx [" + source + "]: " + message) {}

--- a/include/InfluxDBFactory.h
+++ b/include/InfluxDBFactory.h
@@ -29,12 +29,13 @@
 
 #include "InfluxDB.h"
 #include "Transport.h"
+#include "influxdb_export.h"
 
 namespace influxdb
 {
 
 /// \brief InfluxDB factory
-class InfluxDBFactory
+class INFLUXDB_EXPORT InfluxDBFactory
 {
  public:
    /// Disables copy constructor

--- a/include/Point.h
+++ b/include/Point.h
@@ -31,13 +31,15 @@
 #include <chrono>
 #include <variant>
 
+#include "influxdb_export.h"
+
 namespace influxdb
 {
 
 static inline constexpr int defaultFloatsPrecision{18};
 
 /// \brief Represents a point
-class Point
+class INFLUXDB_EXPORT Point
 {
   public:
     /// Constructs point based on measurement name

--- a/include/Transport.h
+++ b/include/Transport.h
@@ -29,12 +29,13 @@
 
 #include <string>
 #include <stdexcept>
+#include "influxdb_export.h"
 
 namespace influxdb
 {
 
 /// \brief Transport interface
-class Transport
+class INFLUXDB_EXPORT Transport
 {
   public:
     Transport() = default;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(InfluxDB
   PRIVATE
     $<$<BOOL:${Boost_FOUND}>:Boost::system>
     CURL::libcurl
+    Threads::Threads
 )
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(InfluxDB
   $<$<BOOL:${Boost_FOUND}>:UnixSocket.cxx>
   HTTP.cxx
 )
-
+generate_export_header(InfluxDB)
 
 target_include_directories(InfluxDB
   PUBLIC
@@ -14,8 +14,9 @@ target_include_directories(InfluxDB
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
+    # for export header
+    ${PROJECT_BINARY_DIR}/src
 )
-
 
 # Link targets
 target_link_libraries(InfluxDB
@@ -33,8 +34,3 @@ target_compile_definitions(InfluxDB
   PRIVATE
     $<$<BOOL:${Boost_FOUND}>:INFLUXDB_WITH_BOOST>
 )
-
-
-if(MSVC)
-  set_target_properties(InfluxDB PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
-endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,12 +6,16 @@
     testFactory.cxx
     testInfluxDB.cxx
   )
-
   foreach (test ${TEST_SRCS})
     get_filename_component(test_name ${test} NAME)
     string(REGEX REPLACE ".cxx" "" test_name ${test_name})
 
-    add_executable(${test_name} ${test})
+    if(${test_name} MATCHES "testUdp")
+      # for testing the not-exported interface of InfluxDB,
+      # we have to explicitly add the sources / symbols
+      set(INFLUXDB_PRIVATE_SRCS ${PROJECT_SOURCE_DIR}/src/HTTP.cxx)
+    endif()
+    add_executable(${test_name} ${test} "${INFLUXDB_PRIVATE_SRCS}")
     target_link_libraries(${test_name}
       PRIVATE
         InfluxDB
@@ -23,6 +27,7 @@
     target_include_directories(${test_name}
             PRIVATE
               ${CMAKE_SOURCE_DIR}/src
+              ${PROJECT_BINARY_DIR}/src
             )
 
     add_test(NAME ${test_name} COMMAND ${test_name})


### PR DESCRIPTION
Instead of exporting all symbols, we only export the public interface.
This has to benefits:
- symbol handling is independent of Linux / Windows
- makes it harder to accidentally use the non-exported interface (e.g. use the not-exported `HTTP` Transport)
- no explicit `__declspec(dllimport)` required on Windows, as this is transparently handled by the export header macros.

By testing that, I also found missing symbols from `pthread` in static builds. Note: This is actually unrelated to the export header stuff.

Note: Technically, this PR is an ABI break, as it is no longer possible to use the `HTTP` transport directly. However, this was never supported as it was only in the public interface by accident (through a transitive include).