### PR TITLE
Improve deployment as subdirectory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,12 @@ jobs:
         run: script/ci_build.sh -DINFLUXCXX_TESTING=ON
       - name: Test
         run: script/ci_test.sh
+      - name: Check deployment as cmake subdirectory
+        run: script/ci_testdeploy.sh -DINFLUXCXX_AS_SUBDIR=ON
       - name: Install
         run: cmake --build build --target install
+      - name: Check installed library
+        run: script/ci_testdeploy.sh -DINFLUXCXX_AS_SUBDIR=OFF
 
   build_windows:
     runs-on: windows-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,14 @@
 
 cmake_minimum_required(VERSION 3.12.0)
 
+# disable testsuite when included
+# using add_subdirectory
+if(DEFINED PROJECT_NAME)
+  set(INCLUDED_AS_SUBPROJECT ON)
+  set(INFLUXCXX_TESTING OFF CACHE BOOL "testing not available in sub-project")
+  set(INFLUXCXX_COVERAGE OFF CACHE BOOL "coverage not available in sub-project")
+endif()
+
 option(BUILD_SHARED_LIBS "Build shared versions of libraries" ON)
 option(INFLUXCXX_TESTING "Enable testing for this component" ON)
 option(INFLUXCXX_COVERAGE "Enable Coverage" OFF)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ add_executable(example-influx main.cpp)
 target_link_libraries(example-influx PRIVATE InfluxData::InfluxDB)
 ```
 
+This target is also provided when the project is included as a subdirectory.
+
+```
+project(example)
+add_subdirectory(influxdb-cxx)
+add_executable(example-influx main.cpp)
+target_link_libraries(example-influx PRIVATE InfluxData::InfluxDB)
+```
+
 ### Basic write
 
 ```cpp

--- a/script/ci_testdeploy.sh
+++ b/script/ci_testdeploy.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# test including influxdb-cxx
+
+set -ex
+PID=$$
+BASEPATH=/tmp/influx-test-${PID}
+
+echo "perform deployment test in ${BASEPATH}"
+mkdir -p ${BASEPATH}/influxdb-cxx
+cp -r ./* ${BASEPATH}/influxdb-cxx
+cp -r script/include_library/* ${BASEPATH}/
+
+cd /tmp/influx-test-${PID}/
+mkdir build && cd build
+cmake "$@" ..
+cmake --build . -j
+
+#cleanup
+rm -r ${BASEPATH}

--- a/script/include_library/CMakeLists.txt
+++ b/script/include_library/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.16)
+project(influxcxx-test)
+
+if(INFLUXCXX_AS_SUBDIR)
+    message(STATUS "include as subdirectory")
+    add_subdirectory(influxdb-cxx)
+else()
+    message(STATUS "include using find_package")
+    find_package(InfluxDB REQUIRED)
+endif()
+
+add_executable(influxcxx-writer main)
+target_link_libraries(influxcxx-writer PRIVATE InfluxData::InfluxDB)

--- a/script/include_library/main.cpp
+++ b/script/include_library/main.cpp
@@ -1,0 +1,7 @@
+// Sample project to check if the deployment process works
+#include <InfluxDBFactory.h>
+
+int main() {
+  auto influxdb = influxdb::InfluxDBFactory::Get("http://localhost:8086?db=test");
+  influxdb->write(influxdb::Point{"test"}.addField("value", 10));
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,10 +12,10 @@ target_include_directories(InfluxDB
   PUBLIC
     $<INSTALL_INTERFACE:include>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    # for export header
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src>
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
-    # for export header
-    ${PROJECT_BINARY_DIR}/src
 )
 
 # Link targets

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,8 @@ add_library(InfluxDB
   $<$<BOOL:${Boost_FOUND}>:UnixSocket.cxx>
   HTTP.cxx
 )
+add_library(InfluxData::InfluxDB ALIAS InfluxDB)
+
 generate_export_header(InfluxDB)
 
 target_include_directories(InfluxDB


### PR DESCRIPTION
I'm really sorry, that my last PR broke the subdirectory integration support.
For that, we have to include the generated header in the public "build interface" as well... Doing CMake right is ridiculously hard.

As the this issue now happened the second time, I added a test to check the deployment as well:

- as a subdirectory
- using the install target

I'm still a bit unsure where to place these scripts. Maybe we should unify that, once you are done with reworking the testing anyways.