### PR TITLE
Fix ptree_bad_path on exploring schema queries

### DIFF
--- a/src/BoostSupport.cxx
+++ b/src/BoostSupport.cxx
@@ -53,7 +53,13 @@ namespace influxdb::internal
 
                 for (const auto& values : series.second.get_child("values"))
                 {
-                    Point point{series.second.get<std::string>("name")};
+                    std::string name;
+                    if(series.second.find("name") != series.second.not_found())
+                    {
+                        name = series.second.get<std::string>("name");
+                    }
+                    Point point{name};
+
                     auto iColumns = columns.begin();
                     auto iValues = values.second.begin();
                     for (; iColumns != columns.end() && iValues != values.second.end(); ++iColumns, ++iValues)


### PR DESCRIPTION
The code used to throw `ptree_bad_path` exception in response to `SHOW SERIES` query. This was caused by the fact, that JSON answer to this query lacks `name` field which could be used to create `influxdb::Point`. This PR adds simple check if `name` field is present before an attempt to read it. If the `name` is not present, `influxdb::Point` with an empty name is created instead. Result of the query can then be properly read from `influxdb::Point::getTags()`.