### PR TITLE
Data kept in native type instead of line protocol strings

### DIFF
--- a/include/InfluxDB.h
+++ b/include/InfluxDB.h
@@ -80,16 +80,19 @@ class INFLUXDB_EXPORT InfluxDB
     /// \param size
     void batchOf(const std::size_t size = 32);
 
+    /// Returns current stores size
+    size_t batchSize();
+
     /// Adds a global tag
     /// \param name
     /// \param value
     void addGlobalTag(std::string_view name, std::string_view value);
 
   private:
-    void addPointToBatch(const Point &point);
+    void addPointToBatch(Point &&point);
 
     /// line protocol batch to be written
-    std::deque<std::string> mLineProtocolBatch;
+    std::deque<Point> mPointBatch;
 
     /// Flag stating whether point buffering is enabled
     bool mIsBatchingActivated;
@@ -106,8 +109,7 @@ class INFLUXDB_EXPORT InfluxDB
     /// List of global tags
     std::string mGlobalTags;
 
-
-  std::string joinLineProtocolBatch() const;
+    std::string joinLineProtocolBatch() const;
 };
 
 } // namespace influxdb

--- a/include/InfluxDB.h
+++ b/include/InfluxDB.h
@@ -80,8 +80,8 @@ class INFLUXDB_EXPORT InfluxDB
     /// \param size
     void batchOf(const std::size_t size = 32);
 
-    /// Returns current stores size
-    size_t batchSize();
+    /// Returns current batch size
+    size_t batchSize() const;
 
     /// Adds a global tag
     /// \param name

--- a/include/Point.h
+++ b/include/Point.h
@@ -87,10 +87,10 @@ protected:
     std::chrono::time_point<std::chrono::system_clock> mTimestamp;
 
     //// Tags    
-    std::deque<std::pair<std::string, std::string>> mTags;
+    std::deque<std::pair<const std::string, const std::string>> mTags;
 
     //// Fields
-    std::deque<std::pair<std::string_view, std::variant<int, long long int, std::string, double>>> mFields;
+    std::deque<std::pair<const std::string, std::variant<int, long long int, std::string, double>>> mFields;
 };
 
 } // namespace influxdb

--- a/include/Point.h
+++ b/include/Point.h
@@ -31,6 +31,7 @@
 #include <string_view>
 #include <chrono>
 #include <variant>
+#include <deque>
 
 #include "influxdb_export.h"
 
@@ -79,21 +80,17 @@ class INFLUXDB_EXPORT Point
     static inline int floatsPrecision{defaultFloatsPrecision};
 
 protected:
-    /// A value
-    std::variant<long long int, std::string, double> mValue;
-
     /// A name
     std::string mMeasurement;
 
     /// A timestamp
     std::chrono::time_point<std::chrono::system_clock> mTimestamp;
 
-    /// Tags
-    std::string mTags;
+    //// Tags    
+    std::deque<std::pair<std::string, std::string>> mTags;
 
-    /// Fields
-    std::string mFields;
-
+    //// Fields
+    std::deque<std::pair<std::string_view, std::variant<int, long long int, std::string, double>>> mFields;
 };
 
 } // namespace influxdb

--- a/src/InfluxDB.cxx
+++ b/src/InfluxDB.cxx
@@ -36,7 +36,7 @@ namespace influxdb
 {
 
 InfluxDB::InfluxDB(std::unique_ptr<Transport> transport) :
-  mLineProtocolBatch{},
+  mPointBatch{},
   mIsBatchingActivated{false},
   mBatchSize{0},
   mTransport(std::move(transport)),
@@ -54,21 +54,28 @@ void InfluxDB::batchOf(const std::size_t size)
   mIsBatchingActivated = true;
 }
 
+size_t InfluxDB::batchSize()
+{
+  return mPointBatch.size();
+}
+
 void InfluxDB::flushBatch()
 {
-  if (mIsBatchingActivated && !mLineProtocolBatch.empty())
+  if (mIsBatchingActivated && !mPointBatch.empty())
   {
     transmit(joinLineProtocolBatch());
-    mLineProtocolBatch.clear();
+    mPointBatch.clear();
   }
 }
 
 std::string InfluxDB::joinLineProtocolBatch() const
 {
   std::string joinedBatch;
-  for (const auto &line : mLineProtocolBatch)
+
+  LineProtocol formatter{mGlobalTags};
+  for (const auto &point : mPointBatch)
   {
-    joinedBatch += line + "\n";
+    joinedBatch += formatter.format(point) + "\n";
   }
 
   joinedBatch.erase(std::prev(joinedBatch.cend()));
@@ -96,7 +103,7 @@ void InfluxDB::write(Point &&point)
 {
   if (mIsBatchingActivated)
   {
-    addPointToBatch(point);
+    addPointToBatch(std::move(point));
   }
   else
   {
@@ -109,9 +116,9 @@ void InfluxDB::write(std::vector<Point> &&points)
 {
   if (mIsBatchingActivated)
   {
-    for (const auto &point : points)
+    for (auto &&point : points)
     {
-      addPointToBatch(point);
+      addPointToBatch(std::move(point));
     }
   }
   else
@@ -129,12 +136,11 @@ void InfluxDB::write(std::vector<Point> &&points)
   }
 }
 
-void InfluxDB::addPointToBatch(const Point &point)
+void InfluxDB::addPointToBatch(Point &&point)
 {
-  LineProtocol formatter{mGlobalTags};
-  mLineProtocolBatch.emplace_back(formatter.format(point));
+  mPointBatch.emplace_back(std::move(point));
 
-  if (mLineProtocolBatch.size() >= mBatchSize)
+  if (mPointBatch.size() >= mBatchSize)
   {
     flushBatch();
   }

--- a/src/InfluxDB.cxx
+++ b/src/InfluxDB.cxx
@@ -54,7 +54,7 @@ void InfluxDB::batchOf(const std::size_t size)
   mIsBatchingActivated = true;
 }
 
-size_t InfluxDB::batchSize()
+size_t InfluxDB::batchSize() const
 {
   return mPointBatch.size();
 }

--- a/src/Point.cxx
+++ b/src/Point.cxx
@@ -96,7 +96,7 @@ std::string Point::getFields() const
 {
   std::string fields;
 
-  for (auto& field : mFields)
+  for (const auto& field : mFields)
   {
     std::stringstream convert;
     convert << std::setprecision(floatsPrecision);
@@ -128,7 +128,7 @@ std::string Point::getTags() const
     }
 
     std::string tags;
-    for (auto& tag : mTags)
+    for (const auto& tag : mTags)
     {
         tags += ",";
         tags += tag.first;


### PR DESCRIPTION
Changes the way data is stored before being sent to the database. Instead of immediate conversion into line protocol strings data (i.e. values, tags and Points) is now stored in the native type and converted only on write (or flush in case of batch writes). This improves the performance (mainly in batch mode) as costly string operations are performed only on flush and not on each write call. Additionally, new function `batchSize()` is introduced to allow user to monitor the size of current batch and perform time-consuming flushing and string operations when convenient.