### PR TITLE
Allow setting CMAKE_INSTALL_LIBDIR from command line

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,9 +55,6 @@ include(GenerateExportHeader)
 # Set fPIC for all targets
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# Set CMAKE_INSTALL_LIBDIR explicitly to lib (to avoid lib64 on CC7)
-set(CMAKE_INSTALL_LIBDIR lib)
-
 # Set the default build type to "RelWithDebInfo"
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo"


### PR DESCRIPTION
Some distros really need `lib64` at 64bit architectures. Make it possible to override the variable through cmake command line.