### PR TITLE
Add soversion for InfluxDB

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,22 @@ add_library(InfluxDB
     )
 add_library(InfluxData::InfluxDB ALIAS InfluxDB)
 
+#
+# Here are a set of rules to help you update your library version information:
+#
+#    If the library source code has changed at all since the last update,
+#        then increment revision (‘c:r:a’ becomes ‘c:r+1:a’).
+#    If any interfaces have been added, removed, or changed since the last update,
+#        increment current, and set revision to 0.
+#    If any interfaces have been added since the last public release,
+#        then increment age.
+#    If any interfaces have been removed or changed since the last public release,
+#        then set age to 0.
+#
+# set_target_properties(InfluxDB PROPERTIES VERSION c.r.a SOVERSION c)
+#
+set_target_properties(InfluxDB PROPERTIES VERSION 0.0.0 SOVERSION 0)
+
 generate_export_header(InfluxDB)
 
 target_include_directories(InfluxDB


### PR DESCRIPTION
Shared object files on UNIX systems frequently have libtool-style versioning. In particular, it is used for automatic dependency tracking in binary packaging managers. In order to be more friendly to Linux systems, the libtool-style versioning is introduced here. Windows system is unaffected by this change.

`c:r:a` has to be adjusted manually before each release basing on the set of the rules.