### PR TITLE
Do not add warning flags if used as a Subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ message(STATUS "~~~ ${PROJECT_NAME} v${PROJECT_VERSION} ~~~")
 
 
 # Add compiler flags for warnings
-if(NOT MSVC)
+if(NOT MSVC AND NOT INCLUDED_AS_SUBPROJECT)
     add_compile_options(-Wall
       -Wextra
       -pedantic


### PR DESCRIPTION
Using a library should not add any warning flags to the top level project (in my opinion). Therefore, I disabled the warning options if influxdb-cxx is included as a subproject.