### PR TITLE
feat: add support for raw TCP endpoints (like QuestDB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ List of supported transport is following:
 | Name        | Dependency  | URI protocol   | Sample URI                            |
 | ----------- |:-----------:|:--------------:| -------------------------------------:|
 | HTTP        | cURL<sup>i)</sup> | `http`/`https` | `http://localhost:8086?db=<db>`      |
+| TCP         | boost       | `tcp`          | `tcp://localhost:8094`                |
 | UDP         | boost       | `udp`          | `udp://localhost:8094`                |
 | Unix socket | boost       | `unix`         | `unix:///tmp/telegraf.sock`           |
 

--- a/src/BoostSupport.cxx
+++ b/src/BoostSupport.cxx
@@ -23,6 +23,7 @@
 
 #include "BoostSupport.h"
 #include "UDP.h"
+#include "TCP.h"
 #include "UnixSocket.h"
 #include <chrono>
 #include <boost/lexical_cast.hpp>
@@ -103,6 +104,11 @@ namespace influxdb::internal
     std::unique_ptr<Transport> withUdpTransport(const http::url& uri)
     {
         return std::make_unique<transports::UDP>(uri.host, uri.port);
+    }
+
+    std::unique_ptr<Transport> withTcpTransport(const http::url& uri)
+    {
+        return std::make_unique<transports::TCP>(uri.host, uri.port);
     }
 
     std::unique_ptr<Transport> withUnixSocketTransport(const http::url& uri)

--- a/src/BoostSupport.h
+++ b/src/BoostSupport.h
@@ -35,5 +35,6 @@ namespace influxdb::internal
     std::vector<Point> queryImpl(Transport* transport, const std::string& query);
 
     std::unique_ptr<Transport> withUdpTransport(const http::url& uri);
+    std::unique_ptr<Transport> withTcpTransport(const http::url& uri);
     std::unique_ptr<Transport> withUnixSocketTransport(const http::url& uri);
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(InfluxDB-BoostSupport OBJECT
     $<$<NOT:$<BOOL:${INFLUXCXX_WITH_BOOST}>>:NoBoostSupport.cxx>
     $<$<BOOL:${INFLUXCXX_WITH_BOOST}>:BoostSupport.cxx>
     $<$<BOOL:${INFLUXCXX_WITH_BOOST}>:UDP.cxx>
+    $<$<BOOL:${INFLUXCXX_WITH_BOOST}>:TCP.cxx>
     $<$<BOOL:${INFLUXCXX_WITH_BOOST}>:UnixSocket.cxx>
     )
 target_include_directories(InfluxDB-BoostSupport PRIVATE ${INTERNAL_INCLUDE_DIRS})
@@ -26,7 +27,7 @@ target_link_libraries(InfluxDB-BoostSupport
 
 # #117: Workaround for Boost ASIO null-dereference
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "12")
-    set_source_files_properties(UDP.cxx UnixSocket.cxx PROPERTIES COMPILE_OPTIONS "-Wno-null-dereference")
+    set_source_files_properties(UDP.cxx TCP.cxx UnixSocket.cxx PROPERTIES COMPILE_OPTIONS "-Wno-null-dereference")
 endif()
 
 add_library(InfluxDB-Internal OBJECT LineProtocol.cxx)

--- a/src/InfluxDBFactory.cxx
+++ b/src/InfluxDBFactory.cxx
@@ -55,6 +55,7 @@ namespace influxdb
     {
         static const std::map<std::string, std::function<std::unique_ptr<Transport>(const http::url&)>> map = {
             {"udp", internal::withUdpTransport},
+            {"tcp", internal::withTcpTransport},
             {"http", internal::withHttpTransport},
             {"https", internal::withHttpTransport},
             {"unix", internal::withUnixSocketTransport},

--- a/src/TCP.cxx
+++ b/src/TCP.cxx
@@ -1,0 +1,75 @@
+// MIT License
+//
+// Copyright (c) 2021 Felix Moessbauer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+///
+/// \author Felix Moessbauer
+///
+
+#include "TCP.h"
+#include "InfluxDBException.h"
+#include <string>
+
+namespace influxdb::transports
+{
+    namespace ba = boost::asio;
+
+    TCP::TCP(const std::string& hostname, int port)
+        : mSocket(mIoService)
+    {
+        ba::ip::tcp::resolver resolver(mIoService);
+        ba::ip::tcp::resolver::query query(hostname, std::to_string(port));
+        ba::ip::tcp::resolver::iterator resolverIterator = resolver.resolve(query);
+        ba::ip::tcp::resolver::iterator end;
+        mEndpoint = *resolverIterator;
+        mSocket.open(mEndpoint.protocol());
+        reconnect();
+    }
+
+    bool TCP::is_connected() const
+    {
+        return mSocket.is_open();
+    }
+
+    void TCP::reconnect()
+    {
+        mSocket.connect(mEndpoint);
+        mSocket.wait(ba::ip::tcp::socket::wait_write);
+    }
+
+    void TCP::send(std::string&& message)
+    {
+        try
+        {
+            message.append("\n");
+            const size_t written = mSocket.write_some(ba::buffer(message, message.size()));
+            if (written != message.size())
+            {
+                throw InfluxDBException(__func__, "error while transmitting data");
+            }
+        }
+        catch (const boost::system::system_error& e)
+        {
+            throw InfluxDBException(__func__, e.what());
+        }
+    }
+
+} // namespace influxdb::transports

--- a/src/TCP.h
+++ b/src/TCP.h
@@ -1,7 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2020-2023 offa
-// Copyright (c) 2019 Adam Wegrzynek
+// Copyright (c) 2021 Felix Moessbauer
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,28 +20,49 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#include "BoostSupport.h"
-#include "InfluxDBException.h"
+///
+/// \author Felix Moessbauer
+///
 
-namespace influxdb::internal
+#ifndef INFLUXDATA_TRANSPORTS_TCP_H
+#define INFLUXDATA_TRANSPORTS_TCP_H
+
+#include "Transport.h"
+
+#include <boost/asio.hpp>
+#include <chrono>
+#include <string>
+
+namespace influxdb::transports
 {
-    std::vector<Point> queryImpl([[maybe_unused]] Transport* transport, [[maybe_unused]] const std::string& query)
-    {
-        throw InfluxDBException("InfluxDB", "Query requires Boost");
-    }
 
-    std::unique_ptr<Transport> withUdpTransport([[maybe_unused]] const http::url& uri)
+    /// \brief TCP transport
+    class TCP : public Transport
     {
-        throw InfluxDBException("InfluxDBFactory", "UDP transport requires Boost");
-    }
+    public:
+        /// Constructor
+        TCP(const std::string& hostname, int port);
 
-    std::unique_ptr<Transport> withTcpTransport([[maybe_unused]] const http::url& uri)
-    {
-        throw InfluxDBException("InfluxDBFactory", "TCP transport requires Boost");
-    }
+        /// Sends blob via TCP
+        void send(std::string&& message) override;
 
-    std::unique_ptr<Transport> withUnixSocketTransport([[maybe_unused]] const http::url& uri)
-    {
-        throw InfluxDBException("InfluxDBFactory", "Unix socket transport requires Boost");
-    }
-}
+        /// check if socket is connected
+        bool is_connected() const;
+
+        /// reconnect socket
+        void reconnect();
+
+    private:
+        /// Boost Asio I/O functionality
+        boost::asio::io_service mIoService;
+
+        /// TCP socket
+        boost::asio::ip::tcp::socket mSocket;
+
+        /// TCP endpoint
+        boost::asio::ip::tcp::endpoint mEndpoint;
+    };
+
+} // namespace influxdb::transports
+
+#endif // INFLUXDATA_TRANSPORTS_TCP_H


### PR DESCRIPTION
QuestDB offers a TCP endpoint for the InfluxDB Line Protocol (ILP) and recently deprecated the corresponding UDP endpoint [[1]](https://questdb.io/blog/2020/07/22/influxdb-lp-on-tcp/). This PR adds TCP endpoint support to influxdb-cxx.

[1] https://questdb.io/blog/2020/07/22/influxdb-lp-on-tcp/