### PR TITLE
Support boolean and unsigned integer field values

### DIFF
--- a/include/Point.h
+++ b/include/Point.h
@@ -52,7 +52,8 @@ namespace influxdb
         Point&& addTag(std::string_view key, std::string_view value);
 
         /// Adds field
-        Point&& addField(std::string_view name, const std::variant<int, long long int, std::string, double>& value);
+        using FieldValue = std::variant<int, long long int, std::string, double, bool, unsigned int, unsigned long long int>;
+        Point&& addField(std::string_view name, const FieldValue& value);
 
         /// Generates current timestamp
         static auto getCurrentTimestamp() -> decltype(std::chrono::system_clock::now());
@@ -90,7 +91,7 @@ namespace influxdb
         std::deque<std::pair<std::string, std::string>> mTags;
 
         //// Fields
-        std::deque<std::pair<std::string, std::variant<int, long long int, std::string, double>>> mFields;
+        std::deque<std::pair<std::string, FieldValue>> mFields;
     };
 
 } // namespace influxdb

--- a/src/Point.cxx
+++ b/src/Point.cxx
@@ -99,16 +99,14 @@ namespace influxdb
 
     std::string Point::getFields() const
     {
-        std::string fields;
-
+        std::stringstream convert;
+        convert << std::setprecision(floatsPrecision) << std::fixed;
+        bool addComma{false};
         for (const auto& field : mFields)
         {
-            std::stringstream convert;
-            convert << std::setprecision(floatsPrecision);
-
-            if (!fields.empty())
+            if (addComma)
             {
-                convert << ",";
+                convert << ',';
             }
 
             convert << field.first << "=";
@@ -118,7 +116,7 @@ namespace influxdb
                            [&convert](long long int v)
                            { convert << v << 'i'; },
                            [&convert](double v)
-                           { convert << std::fixed << v; },
+                           { convert << v; },
                            [&convert](const std::string& v)
                            { convert << '"' << v << '"'; },
                            [&convert](const bool v)
@@ -129,11 +127,10 @@ namespace influxdb
                            { convert << v << 'u'; },
                        },
                        field.second);
-
-            fields += convert.str();
+            addComma = true;
         }
 
-        return fields;
+        return convert.str();
     }
 
     std::string Point::getTags() const

--- a/src/Point.cxx
+++ b/src/Point.cxx
@@ -48,7 +48,7 @@ namespace influxdb
     {
     }
 
-    Point&& Point::addField(std::string_view name, const std::variant<int, long long int, std::string, double>& value)
+    Point&& Point::addField(std::string_view name, const Point::FieldValue& value)
     {
         if (name.empty())
         {
@@ -121,6 +121,12 @@ namespace influxdb
                            { convert << std::fixed << v; },
                            [&convert](const std::string& v)
                            { convert << '"' << v << '"'; },
+                           [&convert](const bool v)
+                           { convert << (v ? "true" : "false"); },
+                           [&convert](const unsigned int v)
+                           { convert << v << 'u'; },
+                           [&convert](const unsigned long long int v)
+                           { convert << v << 'u'; },
                        },
                        field.second);
 

--- a/src/Point.cxx
+++ b/src/Point.cxx
@@ -119,11 +119,11 @@ namespace influxdb
                            { convert << v; },
                            [&convert](const std::string& v)
                            { convert << '"' << v << '"'; },
-                           [&convert](const bool v)
+                           [&convert](bool v)
                            { convert << (v ? "true" : "false"); },
-                           [&convert](const unsigned int v)
+                           [&convert](unsigned int v)
                            { convert << v << 'u'; },
-                           [&convert](const unsigned long long int v)
+                           [&convert](unsigned long long int v)
                            { convert << v << 'u'; },
                        },
                        field.second);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,7 +35,7 @@ add_unittest(LineProtocolTest DEPENDS InfluxDB InfluxDB-Internal)
 add_unittest(InfluxDBTest DEPENDS InfluxDB)
 add_unittest(InfluxDBFactoryTest DEPENDS InfluxDB)
 add_unittest(ProxyTest DEPENDS InfluxDB)
-add_unittest(HttpTest DEPENDS InfluxDB-Core InfluxDB-Internal InfluxDB-BoostSupport CprMock)
+add_unittest(HttpTest DEPENDS InfluxDB-Core InfluxDB-Internal InfluxDB-BoostSupport CprMock Threads::Threads)
 
 add_unittest(NoBoostSupportTest)
 target_sources(NoBoostSupportTest PRIVATE ${PROJECT_SOURCE_DIR}/src/NoBoostSupport.cxx)

--- a/test/LineProtocolTest.cxx
+++ b/test/LineProtocolTest.cxx
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 #include "LineProtocol.h"
+#include <limits>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_all.hpp>
 
@@ -55,6 +56,10 @@ namespace influxdb::test
                                .addField("longlong_value", 1234567890LL)
                                .addField("double_value", 123.4567)
                                .addField("string_value", "abc def ghi")
+                               .addField("bool_true_field", true)
+                               .addField("bool_false_field", false)
+                               .addField("uint_field", std::numeric_limits<unsigned int>::max())
+                               .addField("ulonglong_field", std::numeric_limits<unsigned long long int>::max())
                                .setTimestamp(ignoreTimestamp);
 
         const LineProtocol lineProtocol;
@@ -62,7 +67,11 @@ namespace influxdb::test
                                                        "int_value=567i,"
                                                        "longlong_value=1234567890i,"
                                                        "double_value=123.45[0-9]*,"
-                                                       "string_value=\"abc def ghi\""
+                                                       "string_value=\"abc def ghi\","
+                                                       "bool_true_field=true,"
+                                                       "bool_false_field=false,"
+                                                       "uint_field=4294967295u,"
+                                                       "ulonglong_field=18446744073709551615u"
                                                        " 54000000"));
     }
 

--- a/test/PointTest.cxx
+++ b/test/PointTest.cxx
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 #include "Point.h"
+#include <limits>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_all.hpp>
 
@@ -53,12 +54,22 @@ namespace influxdb::test
                                .addField("int_field", 3)
                                .addField("longlong_field", 1234LL)
                                .addField("string_field", "string value")
-                               .addField("double_field", 3.859);
+                               .addField("double_field", double{3.859})
+                               .addField("bool_true_field", true)
+                               .addField("bool_false_field", false)
+                               .addField("uint_field", std::numeric_limits<unsigned int>::max())
+                               .addField("ulonglong_field", std::numeric_limits<unsigned long long int>::max());
 
+        // Set float precision to default for this test to ensure the expected double field value
+        Point::floatsPrecision = defaultFloatsPrecision;
         CHECK_THAT(point.getFields(), Equals("int_field=3i,"
                                              "longlong_field=1234i,"
                                              "string_field=\"string value\","
-                                             "double_field=3.858999999999999986"));
+                                             "double_field=3.858999999999999986,"
+                                             "bool_true_field=true,"
+                                             "bool_false_field=false,"
+                                             "uint_field=4294967295u,"
+                                             "ulonglong_field=18446744073709551615u"));
     }
 
     TEST_CASE("Field with empty name is not added", "[PointTest]")
@@ -156,12 +167,20 @@ namespace influxdb::test
                                .addField("longlong_field", 123456790LL)
                                .addField("string_field", "str")
                                .addField("double_field", 1.81)
+                               .addField("bool_true_field", true)
+                               .addField("bool_false_field", false)
+                               .addField("uint_field", std::numeric_limits<unsigned int>::max())
+                               .addField("ulonglong_field", std::numeric_limits<unsigned long long int>::max())
                                .setTimestamp(ignoreTimestamp);
 
         CHECK_THAT(point.toLineProtocol(), Equals("test int_field=12i,"
                                                   "longlong_field=123456790i,"
                                                   "string_field=\"str\","
-                                                  "double_field=1.81000 1230000000"));
+                                                  "double_field=1.81000,"
+                                                  "bool_true_field=true,"
+                                                  "bool_false_field=false,"
+                                                  "uint_field=4294967295u,"
+                                                  "ulonglong_field=18446744073709551615u 1230000000"));
     }
 
     TEST_CASE("Line protocol of measurement with tag", "[PointTest]")


### PR DESCRIPTION
Add support for [Boolean](https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol/#boolean) and [UInteger](https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol/#uinteger) types for point field values. Updates `Point` and `LineProtocol` unit tests accordingly.

Additionally, made a small change to the `Point::getFields` loop to stop constructing a separate stringstream for each field.


