### PR TITLE
Escape special characters in Line protocol

### DIFF
--- a/include/Point.h
+++ b/include/Point.h
@@ -82,8 +82,16 @@ namespace influxdb
         /// Fields getter
         std::string getFields() const;
 
+        /// Get fields as a std::deque
+        using FieldsDeque = std::deque<std::pair<std::string, FieldValue>>;
+        const FieldsDeque& getFieldsDeque() const;
+
         /// Tags getter
         std::string getTags() const;
+
+        /// Get tags as a std::deque
+        using TagsDeque = std::deque<std::pair<std::string, std::string>>;
+        const TagsDeque& getTagsDeque() const;
 
         /// Precision for float fields
         static inline int floatsPrecision{defaultFloatsPrecision};
@@ -96,10 +104,10 @@ namespace influxdb
         std::chrono::time_point<std::chrono::system_clock> mTimestamp;
 
         //// Tags
-        std::deque<std::pair<std::string, std::string>> mTags;
+        TagsDeque mTags;
 
         //// Fields
-        std::deque<std::pair<std::string, FieldValue>> mFields;
+        FieldsDeque mFields;
     };
 
 } // namespace influxdb

--- a/src/InfluxDB.cxx
+++ b/src/InfluxDB.cxx
@@ -95,9 +95,9 @@ namespace influxdb
         {
             mGlobalTags += ",";
         }
-        mGlobalTags += name;
+        mGlobalTags += LineProtocol::EscapeStringElement(LineProtocol::ElementType::TagKey,name);
         mGlobalTags += "=";
-        mGlobalTags += value;
+        mGlobalTags += LineProtocol::EscapeStringElement(LineProtocol::ElementType::TagValue,value);
     }
 
     void InfluxDB::transmit(std::string&& point)

--- a/src/LineProtocol.h
+++ b/src/LineProtocol.h
@@ -32,6 +32,7 @@ namespace influxdb
     {
     public:
         LineProtocol();
+        // Caller must ensure that the tags string is correctly escaped
         explicit LineProtocol(const std::string& tags);
 
         std::string format(const Point& point) const;

--- a/src/LineProtocol.h
+++ b/src/LineProtocol.h
@@ -24,6 +24,8 @@
 
 #include "Point.h"
 
+#include <string>
+
 namespace influxdb
 {
     class LineProtocol
@@ -33,6 +35,20 @@ namespace influxdb
         explicit LineProtocol(const std::string& tags);
 
         std::string format(const Point& point) const;
+
+        enum class ElementType
+        {
+            Measurement,
+            TagKey,
+            TagValue,
+            FieldKey,
+            FieldValue
+        };
+
+        // Escapes special characters in a string element according to the
+        // InfluxDB line protocol specification.
+        // https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol/#special-characters
+        static std::string EscapeStringElement(ElementType type, std::string_view stringElement);
 
     private:
         std::string globalTags;

--- a/src/Point.cxx
+++ b/src/Point.cxx
@@ -34,14 +34,16 @@
 
 namespace influxdb
 {
-
-    template <class... Ts>
-    struct overloaded : Ts...
+    namespace
     {
-        using Ts::operator()...;
-    };
-    template <class... Ts>
-    overloaded(Ts...) -> overloaded<Ts...>;
+        template <class... Ts>
+        struct overloaded : Ts...
+        {
+            using Ts::operator()...;
+        };
+        template <class... Ts>
+        overloaded(Ts...) -> overloaded<Ts...>;
+    }
 
     Point::Point(const std::string& measurement)
         : mMeasurement(measurement), mTimestamp(std::chrono::system_clock::now()), mTags({}), mFields({})

--- a/src/Point.cxx
+++ b/src/Point.cxx
@@ -133,6 +133,11 @@ namespace influxdb
         return convert.str();
     }
 
+    const Point::FieldsDeque& Point::getFieldsDeque() const
+    {
+        return mFields;
+    }
+
     std::string Point::getTags() const
     {
         if (mTags.empty())
@@ -150,6 +155,11 @@ namespace influxdb
         }
 
         return tags.substr(1, tags.size());
+    }
+
+    const Point::TagsDeque& Point::getTagsDeque() const
+    {
+        return mTags;
     }
 
 } // namespace influxdb

--- a/test/LineProtocolTest.cxx
+++ b/test/LineProtocolTest.cxx
@@ -139,4 +139,75 @@ namespace influxdb::test
         const LineProtocol lineProtocol{"a=0,b=1,c=2"};
         CHECK_THAT(lineProtocol.format(point), Equals(R"(p1,a=0,b=1,c=2,pointtag=3 n=1i 54000000)"));
     }
+
+    TEST_CASE("Escapes Measurement string element", "[LineProtocolTest]")
+    {
+        // Measurement must escape comma and space characters
+        CHECK_THAT(LineProtocol::EscapeStringElement(LineProtocol::ElementType::Measurement, "no_escape"),
+                   Equals("no_escape"));
+        CHECK_THAT(LineProtocol::EscapeStringElement(LineProtocol::ElementType::Measurement, "escape space"),
+                   Equals(R"(escape\ space)"));
+        CHECK_THAT(LineProtocol::EscapeStringElement(LineProtocol::ElementType::Measurement, "escape,comma"),
+                   Equals(R"(escape\,comma)"));
+        CHECK_THAT(LineProtocol::EscapeStringElement(LineProtocol::ElementType::Measurement, "escape, multiple"),
+                   Equals(R"(escape\,\ multiple)"));
+    }
+
+    TEST_CASE("Escapes Tag key string element", "[LineProtocolTest]")
+    {
+        // Tag key must escape comma, equals sign and space characters
+        CHECK_THAT(LineProtocol::EscapeStringElement(LineProtocol::ElementType::TagKey, "no_escape"),
+                   Equals("no_escape"));
+        CHECK_THAT(LineProtocol::EscapeStringElement(LineProtocol::ElementType::TagKey, "escape,comma"),
+                   Equals(R"(escape\,comma)"));
+        CHECK_THAT(LineProtocol::EscapeStringElement(LineProtocol::ElementType::TagKey, "escape space"),
+                   Equals(R"(escape\ space)"));
+        CHECK_THAT(LineProtocol::EscapeStringElement(LineProtocol::ElementType::TagKey, "escape=equal"),
+                   Equals(R"(escape\=equal)"));
+        CHECK_THAT(LineProtocol::EscapeStringElement(LineProtocol::ElementType::TagKey, "escape = multiple,"),
+                   Equals(R"(escape\ \=\ multiple\,)"));
+    }
+
+    TEST_CASE("Escapes Tag value string element", "[LineProtocolTest]")
+    {
+        // Tag value must escape comma, equals sign and space characters
+        CHECK_THAT(LineProtocol::EscapeStringElement(LineProtocol::ElementType::TagValue, "no_escape"),
+                   Equals("no_escape"));
+        CHECK_THAT(LineProtocol::EscapeStringElement(LineProtocol::ElementType::TagValue, "escape,comma"),
+                   Equals(R"(escape\,comma)"));
+        CHECK_THAT(LineProtocol::EscapeStringElement(LineProtocol::ElementType::TagValue, "escape space"),
+                   Equals(R"(escape\ space)"));
+        CHECK_THAT(LineProtocol::EscapeStringElement(LineProtocol::ElementType::TagValue, "escape=equal"),
+                   Equals(R"(escape\=equal)"));
+        CHECK_THAT(LineProtocol::EscapeStringElement(LineProtocol::ElementType::TagValue, "escape = multiple,"),
+                   Equals(R"(escape\ \=\ multiple\,)"));
+    }
+
+    TEST_CASE("Escapes Field key string element", "[LineProtocolTest]")
+    {
+        // Field key must escape comma, equals sign and space characters
+        CHECK_THAT(LineProtocol::EscapeStringElement(LineProtocol::ElementType::FieldKey, "no_escape"),
+                   Equals("no_escape"));
+        CHECK_THAT(LineProtocol::EscapeStringElement(LineProtocol::ElementType::FieldKey, "escape,comma"),
+                   Equals(R"(escape\,comma)"));
+        CHECK_THAT(LineProtocol::EscapeStringElement(LineProtocol::ElementType::FieldKey, "escape space"),
+                   Equals(R"(escape\ space)"));
+        CHECK_THAT(LineProtocol::EscapeStringElement(LineProtocol::ElementType::FieldKey, "escape=equal"),
+                   Equals(R"(escape\=equal)"));
+        CHECK_THAT(LineProtocol::EscapeStringElement(LineProtocol::ElementType::FieldKey, "escape = multiple,"),
+                   Equals(R"(escape\ \=\ multiple\,)"));
+    }
+
+    TEST_CASE("Escapes Field value string element", "[LineProtocolTest]")
+    {
+        // Field value must escape double quote and backslash characters
+        CHECK_THAT(LineProtocol::EscapeStringElement(LineProtocol::ElementType::FieldValue, "no_escape"),
+                   Equals("no_escape"));
+        CHECK_THAT(LineProtocol::EscapeStringElement(LineProtocol::ElementType::FieldValue, R"(escape"quote)"),
+                   Equals(R"(escape\"quote)"));
+        CHECK_THAT(LineProtocol::EscapeStringElement(LineProtocol::ElementType::FieldValue, R"(escape\backslash)"),
+                   Equals(R"(escape\\backslash)"));
+        CHECK_THAT(LineProtocol::EscapeStringElement(LineProtocol::ElementType::FieldValue, R"(escape\"both)"),
+                   Equals(R"(escape\\\"both)"));
+    }
 }

--- a/test/LineProtocolTest.cxx
+++ b/test/LineProtocolTest.cxx
@@ -210,4 +210,14 @@ namespace influxdb::test
         CHECK_THAT(LineProtocol::EscapeStringElement(LineProtocol::ElementType::FieldValue, R"(escape\"both)"),
                    Equals(R"(escape\\\"both)"));
     }
+
+    TEST_CASE("Escapes all element types", "[LineProtocolTest]")
+    {
+        const auto point = Point{"measurement, "}
+                               .addTag("tag,= key", "tag,= value")
+                               .addField("field,= key", R"("field\value")")
+                               .setTimestamp(ignoreTimestamp);
+        const LineProtocol lineProtocol{};
+        CHECK_THAT(lineProtocol.format(point), Equals(R"(measurement\,\ ,tag\,\=\ key=tag\,\=\ value field\,\=\ key="\"field\\value\"" 54000000)"));
+    }
 }

--- a/test/system/InfluxDBST.cxx
+++ b/test/system/InfluxDBST.cxx
@@ -26,9 +26,15 @@ namespace influxdb::test
 {
     namespace
     {
+        std::size_t querySize(influxdb::InfluxDB& db, const std::string& measurement, const std::string& tag)
+        {
+            // Quote the measurement name to avoid escaped characters being incorrectly interpreted
+            return db.query(R"(select * from ")" + measurement + R"(" where type=')" + tag + "'").size();
+        }
+
         std::size_t querySize(influxdb::InfluxDB& db, const std::string& tag)
         {
-            return db.query("select * from x where type='" + tag + "'").size();
+            return querySize(db, "x", tag);
         }
     }
 
@@ -192,4 +198,65 @@ namespace influxdb::test
             db->execute("drop database st_db");
         }
     }
+
+    TEST_CASE("String Element Escaping", "[InfluxDBST]")
+    {
+        using namespace Catch::Matchers;
+
+        const std::string dbName{"st_escaped_db"};
+        const std::string pointType{"escaped"};
+        auto db = configure(dbName);
+
+        // String elements which need to be escaped in line protocol
+        const std::string unescapedMeasurementName{"esc, measurement"};
+        const std::string unescapedTagKey{"esc,= tag"};
+        const std::string unescapedTagValue{"esc,= value"};
+        const std::string unescapedFieldKey{"esc,= field"};
+        const std::string unescapedFieldValue{R"(esc"\value)"};
+
+        SECTION("Create test database")
+        {
+            db->createDatabaseIfNotExists();
+            CHECK_THAT(db->execute("show databases"), ContainsSubstring(dbName));
+        }
+
+        SECTION("Write point with escaped string elements")
+        {
+            db->createDatabaseIfNotExists();
+            CHECK(querySize(*db, unescapedMeasurementName, pointType) == 0);
+            db->write(Point{unescapedMeasurementName}.addTag(unescapedTagKey, unescapedTagValue).addField(unescapedFieldKey, unescapedFieldValue).addTag("type", pointType));
+            CHECK(querySize(*db, unescapedMeasurementName, pointType) == 1);
+        }
+
+        SECTION("Queried point string elements should be unescaped")
+        {
+            const auto response{db->query(R"(select * from ")" + unescapedMeasurementName + R"(" where type=')" + pointType + "'")};
+            CHECK(response.size() == 1);
+
+            const Point& point{response.at(0)};
+
+            // Measurement
+            CHECK(point.getName() == unescapedMeasurementName);
+
+            // Tags
+            const Point::TagsDeque& tags{point.getTagsDeque()};
+            CHECK(tags.size() == 3);
+            // Should contain the unescaped tag key and value
+            CHECK(tags.end() != std::find(tags.begin(), tags.end(), Point::TagsDeque::value_type{unescapedTagKey, unescapedTagValue}));
+            CHECK(tags.end() != std::find(tags.begin(), tags.end(), Point::TagsDeque::value_type{"type", "escaped"}));
+            // Queried string values actually end up in the tags (see queryImpl)
+            CHECK(tags.end() != std::find(tags.begin(), tags.end(), Point::TagsDeque::value_type{unescapedFieldKey, unescapedFieldValue}));
+
+            // Fields
+            const Point::FieldsDeque& fields{point.getFieldsDeque()};
+            // String fields are put in the tags (see above)
+            CHECK(fields.size() == 0);
+        }
+
+        SECTION("Cleanup")
+        {
+            db->execute("drop database " + dbName);
+        }
+    }
+
 }


### PR DESCRIPTION
This resolves #178 by adding support for escaping special characters within string elements in Line Protocol as [described](https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol/#special-characters) in the Line Protocol syntax.

The main functional changes are:
* Add a string escaping function to `LineProtocol` which supports the Element types from the specification.
* Move responsibility for formatting (and escaping) Point Tags and Fields into `LineProtocol::format`
* Ensure that Global Tags (added via the `InfluxDB` class) are escaped

The existing `getTags` and `getFields` members of the `Point` class are preserved. This has two benefits:
1. Any existing users of these functions should be unaffected hence backwards compatibility is maintained
2. Tags and Fields read from a `Point` are not escaped thus query results are correct.

This change also exposes const access to `Point` tag and field queues. This may be helpful for users of `InfluxDB::query` rather than having to parse the string of `Point::get[Field|Tag]` or subclass `Point`.