### PR TITLE
Respect UDP maximum packet size when sending batched points

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,9 @@ jobs:
         run: script/ci_setup.sh
       - name: Install Boost
         if: ${{ matrix.boost == true }}
-        run: apt-get install -y libboost-system-dev
+        run: |
+          apt update
+          apt -o Acquire::Retries=3 install -y libboost-system-dev
       - name: Build
         run: script/ci_build.sh -DINFLUXCXX_WITH_BOOST=${{ matrix.boost }}
       - name: Check deployment as cmake subdirectory
@@ -58,7 +60,8 @@ jobs:
       - name: Setup
         run: |
           pip install -U conan
-          sudo apt-get install -y libcurl4-openssl-dev
+          sudo apt update
+          sudo apt -o Acquire::Retries=3 install -y libcurl4-openssl-dev
           echo "~/.local/bin" >> $GITHUB_PATH
       - name: Setup Conan
         run: conan profile detect

--- a/.github/workflows/systemtest.yml
+++ b/.github/workflows/systemtest.yml
@@ -21,6 +21,9 @@ jobs:
           INFLUXDB_HTTP_AUTH_ENABLED: ${{ matrix.auth_enabled }}
           INFLUXDB_ADMIN_USER: st_admin
           INFLUXDB_ADMIN_PASSWORD: st_admin_pw
+          INFLUXDB_UDP_ENABLED: true
+          INFLUXDB_UDP_DATABASE: st_udp
+          INFLUXDB_UDP_BATCH_TIMEOUT: 10ms
     env:
       INFLUXDBCXX_SYSTEMTEST_HOST: influxdb
       INFLUXDBCXX_SYSTEMTEST_USER: st_admin

--- a/include/InfluxDB.h
+++ b/include/InfluxDB.h
@@ -110,9 +110,6 @@ namespace influxdb
         /// Underlying transport UDP/HTTP/Unix socket
         std::unique_ptr<Transport> mTransport;
 
-        /// Transmits string over transport
-        void transmit(std::string&& point);
-
         /// List of global tags
         std::string mGlobalTags;
 

--- a/include/Transport.h
+++ b/include/Transport.h
@@ -46,6 +46,9 @@ namespace influxdb
         /// Sends string blob
         virtual void send(std::string&& message) = 0;
 
+        /// Maximum message size which can be sent using the send method
+        virtual std::size_t getMaxMessageSize() const = 0;
+
         /// Sends request
         virtual std::string query([[maybe_unused]] const std::string& query)
         {

--- a/src/BoostSupport.cxx
+++ b/src/BoostSupport.cxx
@@ -103,12 +103,19 @@ namespace influxdb::internal
 
     std::unique_ptr<Transport> withUdpTransport(const http::url& uri)
     {
-        return std::make_unique<transports::UDP>(uri.host, uri.port);
+        static constexpr std::uint16_t INFLUXDB_UDP_PORT{8089};
+        const std::uint16_t port{
+            http::url::PORT_NOT_SET == uri.port ? INFLUXDB_UDP_PORT : static_cast<std::uint16_t>(uri.port)};
+        return std::make_unique<transports::UDP>(uri.host, port);
     }
 
     std::unique_ptr<Transport> withTcpTransport(const http::url& uri)
     {
-        return std::make_unique<transports::TCP>(uri.host, uri.port);
+        // Default QuestDB TCP port (TCP support was added for this purpose)
+        static constexpr std::uint16_t QUESTDB_TCP_PORT{9009};
+        const std::uint16_t port{
+            http::url::PORT_NOT_SET == uri.port ? QUESTDB_TCP_PORT : static_cast<std::uint16_t>(uri.port)};
+        return std::make_unique<transports::TCP>(uri.host, port);
     }
 
     std::unique_ptr<Transport> withUnixSocketTransport(const http::url& uri)

--- a/src/HTTP.cxx
+++ b/src/HTTP.cxx
@@ -28,6 +28,8 @@
 #include "HTTP.h"
 #include "InfluxDBException.h"
 
+#include <limits>
+
 namespace influxdb::transports
 {
     namespace

--- a/src/HTTP.cxx
+++ b/src/HTTP.cxx
@@ -111,7 +111,7 @@ namespace influxdb::transports
 
     std::size_t HTTP::getMaxMessageSize() const
     {
-        return std::numeric_limits<std::size_t>::max();
+        return (std::numeric_limits<std::size_t>::max)();
     }
 
     void HTTP::setProxy(const Proxy& proxy)

--- a/src/HTTP.cxx
+++ b/src/HTTP.cxx
@@ -107,6 +107,11 @@ namespace influxdb::transports
         checkResponse(response);
     }
 
+    std::size_t HTTP::getMaxMessageSize() const
+    {
+        return std::numeric_limits<std::size_t>::max();
+    }
+
     void HTTP::setProxy(const Proxy& proxy)
     {
         session.SetProxies(cpr::Proxies{{"http", proxy.getProxy()}, {"https", proxy.getProxy()}});

--- a/src/HTTP.h
+++ b/src/HTTP.h
@@ -47,6 +47,9 @@ namespace influxdb::transports
         ///  \throw InfluxDBException	when send fails
         void send(std::string&& lineprotocol) override;
 
+        /// Returns maximum message size
+        std::size_t getMaxMessageSize() const override;
+
         /// Queries database
         /// \throw InfluxDBException	when query fails
         std::string query(const std::string& query) override;

--- a/src/InfluxDB.cxx
+++ b/src/InfluxDB.cxx
@@ -46,15 +46,15 @@ namespace influxdb
             bool messageSizeExceeded{false};
 
             const auto maxMessageSize{transport->getMaxMessageSize()};
-            for (const auto& point: points)
+            for (const auto& point : points)
             {
                 auto formattedPoint{formatter.format(point)};
-                auto GetRequiredSize{[&appendNewLine](const std::string& formattedPoint) -> std::size_t
-                {
-                    // Have to recalculate because the point may fit in a new message if
-                    // it doesn't have a preceding newline.
-                    return appendNewLine ? 1 + formattedPoint.size() : formattedPoint.size();
-                }};
+                auto GetRequiredSize{[&appendNewLine](const std::string& fp) -> std::size_t
+                                     {
+                                         // Have to recalculate because the point may fit in a new message if
+                                         // it doesn't have a preceding newline.
+                                         return appendNewLine ? 1 + fp.size() : fp.size();
+                                     }};
 
                 while (maxMessageSize < lineProtocol.size() + GetRequiredSize(formattedPoint))
                 {
@@ -79,7 +79,7 @@ namespace influxdb
                     }
                 }
 
-                if (! formattedPoint.empty())
+                if (!formattedPoint.empty())
                 {
                     if (appendNewLine)
                     {

--- a/src/InfluxDBFactory.cxx
+++ b/src/InfluxDBFactory.cxx
@@ -62,11 +62,7 @@ namespace influxdb
         };
 
         auto urlCopy = url;
-        http::url parsedUrl = http::ParseHttpUrl(urlCopy);
-        if (parsedUrl.protocol.empty())
-        {
-            throw InfluxDBException("Ill-formed URI");
-        }
+        http::url parsedUrl{http::ParseHttpUrl(urlCopy)};
 
         const auto iterator = map.find(parsedUrl.protocol);
         if (iterator == map.end())

--- a/src/TCP.cxx
+++ b/src/TCP.cxx
@@ -32,7 +32,7 @@ namespace influxdb::transports
 {
     namespace ba = boost::asio;
 
-    TCP::TCP(const std::string& hostname, int port)
+    TCP::TCP(const std::string& hostname, std::uint16_t port)
         : mSocket(mIoService)
     {
         ba::ip::tcp::resolver resolver(mIoService);

--- a/src/TCP.cxx
+++ b/src/TCP.cxx
@@ -26,6 +26,7 @@
 
 #include "TCP.h"
 #include "InfluxDBException.h"
+#include <limits>
 #include <string>
 
 namespace influxdb::transports

--- a/src/TCP.cxx
+++ b/src/TCP.cxx
@@ -72,4 +72,9 @@ namespace influxdb::transports
         }
     }
 
+    std::size_t TCP::getMaxMessageSize() const
+    {
+        return std::numeric_limits<std::size_t>::max();
+    }
+
 } // namespace influxdb::transports

--- a/src/TCP.cxx
+++ b/src/TCP.cxx
@@ -75,7 +75,7 @@ namespace influxdb::transports
 
     std::size_t TCP::getMaxMessageSize() const
     {
-        return std::numeric_limits<std::size_t>::max();
+        return (std::numeric_limits<std::size_t>::max)();
     }
 
 } // namespace influxdb::transports

--- a/src/TCP.h
+++ b/src/TCP.h
@@ -47,6 +47,8 @@ namespace influxdb::transports
         /// Sends blob via TCP
         void send(std::string&& message) override;
 
+        std::size_t getMaxMessageSize() const override;
+
         /// check if socket is connected
         bool is_connected() const;
 

--- a/src/TCP.h
+++ b/src/TCP.h
@@ -29,6 +29,7 @@
 
 #include "Transport.h"
 
+#include <cstdint>
 #include <boost/asio.hpp>
 #include <chrono>
 #include <string>
@@ -41,7 +42,7 @@ namespace influxdb::transports
     {
     public:
         /// Constructor
-        TCP(const std::string& hostname, int port);
+        TCP(const std::string& hostname, std::uint16_t port);
 
         /// Sends blob via TCP
         void send(std::string&& message) override;

--- a/src/UDP.cxx
+++ b/src/UDP.cxx
@@ -27,6 +27,7 @@
 
 #include "UDP.h"
 #include "InfluxDBException.h"
+#include <limits>
 #include <string>
 
 namespace influxdb::transports

--- a/src/UDP.cxx
+++ b/src/UDP.cxx
@@ -32,7 +32,7 @@
 namespace influxdb::transports
 {
 
-    UDP::UDP(const std::string& hostname, int port)
+    UDP::UDP(const std::string& hostname, std::uint16_t port)
         : mSocket(mIoService, boost::asio::ip::udp::endpoint(boost::asio::ip::udp::v4(), 0))
     {
         boost::asio::ip::udp::resolver resolver(mIoService);

--- a/src/UDP.cxx
+++ b/src/UDP.cxx
@@ -76,7 +76,7 @@ namespace influxdb::transports
     std::size_t UDP::getMaxMessageSize() const
     {
         // UDP header has a 16-bit length field
-        static constexpr std::size_t maxLengthValue{std::numeric_limits<std::uint16_t>::max()};
+        static constexpr std::size_t maxLengthValue{(std::numeric_limits<std::uint16_t>::max)()};
         static constexpr std::size_t udpHeaderSize{8};
         // Currently only IPv4 is supported
         static constexpr std::size_t ipv4HeaderSize{20};

--- a/src/UDP.cxx
+++ b/src/UDP.cxx
@@ -60,4 +60,16 @@ namespace influxdb::transports
         }
     }
 
+    std::size_t UDP::getMaxMessageSize() const
+    {
+        // UDP header has a 16-bit length field
+        static constexpr std::size_t maxLengthValue{std::numeric_limits<std::uint16_t>::max()};
+        static constexpr std::size_t udpHeaderSize{8};
+        // Currently only IPv4 is supported
+        static constexpr std::size_t ipv4HeaderSize{20};
+        // Max UDP data size for IPv4 is 65535 - 8 - 20 = 65507
+        static constexpr std::size_t maxUDPDataSize{maxLengthValue - udpHeaderSize - ipv4HeaderSize};
+        return maxUDPDataSize;
+    }
+
 } // namespace influxdb::transports

--- a/src/UDP.h
+++ b/src/UDP.h
@@ -48,6 +48,8 @@ namespace influxdb::transports
         /// Sends blob via UDP
         void send(std::string&& message) override;
 
+        std::size_t getMaxMessageSize() const override;
+
     private:
         /// Boost Asio I/O functionality
         boost::asio::io_service mIoService;

--- a/src/UDP.h
+++ b/src/UDP.h
@@ -30,6 +30,7 @@
 
 #include "Transport.h"
 
+#include <cstdint>
 #include <boost/asio.hpp>
 #include <chrono>
 #include <string>
@@ -42,7 +43,7 @@ namespace influxdb::transports
     {
     public:
         /// Constructor
-        UDP(const std::string& hostname, int port);
+        UDP(const std::string& hostname, std::uint16_t port);
 
         /// Sends blob via UDP
         void send(std::string&& message) override;

--- a/src/UnixSocket.cxx
+++ b/src/UnixSocket.cxx
@@ -39,6 +39,11 @@ namespace influxdb::transports
         mSocket.open();
     }
 
+    std::size_t UnixSocket::getMaxMessageSize() const
+    {
+        return std::numeric_limits<std::size_t>::max();
+    }
+
     void UnixSocket::send(std::string&& message)
     {
         try

--- a/src/UnixSocket.cxx
+++ b/src/UnixSocket.cxx
@@ -27,6 +27,7 @@
 
 #include "UnixSocket.h"
 #include "InfluxDBException.h"
+#include <limits>
 #include <string>
 
 namespace influxdb::transports

--- a/src/UnixSocket.cxx
+++ b/src/UnixSocket.cxx
@@ -42,7 +42,7 @@ namespace influxdb::transports
 
     std::size_t UnixSocket::getMaxMessageSize() const
     {
-        return std::numeric_limits<std::size_t>::max();
+        return (std::numeric_limits<std::size_t>::max)();
     }
 
     void UnixSocket::send(std::string&& message)

--- a/src/UnixSocket.h
+++ b/src/UnixSocket.h
@@ -45,6 +45,10 @@ namespace influxdb::transports
         /// \param message   r-value string formated
         void send(std::string&& message) override;
 
+        /// Returns maximum message size
+        /// \return maximum message size
+        std::size_t getMaxMessageSize() const override;
+
     private:
         /// Boost Asio I/O functionality
         boost::asio::io_service mIoService;

--- a/src/UriParser.h
+++ b/src/UriParser.h
@@ -20,16 +20,20 @@
 #ifndef INFLUXDATA_HTTPPARSER_H
 #define INFLUXDATA_HTTPPARSER_H
 
+#include <cstdint>
+#include <cstdlib>
 #include <iostream>
+#include <limits>
 #include <string>
-#include <stdlib.h>
 
+#include "InfluxDBException.h"
 
 namespace http
 {
     struct url
     {
         std::string protocol, user, password, host, path, search, url;
+        static constexpr int PORT_NOT_SET = -1;
         int port;
     };
 
@@ -72,17 +76,25 @@ namespace http
     //--- Extractors -------------------------------------------------------------------~
     static inline int ExtractPort(std::string& hostport)
     {
-        int port;
-        std::string portstring = TailSlice(hostport, ":");
-        try
+        const std::string portstring{TailSlice(hostport, ":")};
+        if (portstring.empty())
         {
-            port = atoi(portstring.c_str());
+            // If portstring is empty there was either:
+            //  * no colon delimiter
+            //  * a colon delimiter but no port
+            return url::PORT_NOT_SET;
         }
-        catch (const std::exception&)
+        errno = 0;
+        char* str_end{nullptr};
+        const long port{strtol(portstring.c_str(), &str_end, 10)};
+        if ((errno != 0) ||
+            (str_end == portstring.c_str()) ||
+            (port < std::numeric_limits<std::uint16_t>::min()) ||
+            (port > std::numeric_limits<std::uint16_t>::max()))
         {
-            port = -1;
+            throw influxdb::InfluxDBException("Ill-formed URI, invalid port");
         }
-        return port;
+        return static_cast<std::uint16_t>(port);
     }
 
     static inline std::string ExtractPath(std::string& in)
@@ -91,7 +103,12 @@ namespace http
     }
     static inline std::string ExtractProtocol(std::string& in)
     {
-        return HeadSlice(in, "://");
+        auto protocol{HeadSlice(in, "://")};
+        if (protocol.empty())
+        {
+            throw influxdb::InfluxDBException("Ill-formed URI, no protocol");
+        }
+        return protocol;
     }
     static inline std::string ExtractSearch(std::string& in)
     {

--- a/src/UriParser.h
+++ b/src/UriParser.h
@@ -89,8 +89,8 @@ namespace http
         const long port{strtol(portstring.c_str(), &str_end, 10)};
         if ((errno != 0) ||
             (str_end == portstring.c_str()) ||
-            (port < std::numeric_limits<std::uint16_t>::min()) ||
-            (port > std::numeric_limits<std::uint16_t>::max()))
+            (port < (std::numeric_limits<std::uint16_t>::min)()) ||
+            (port > (std::numeric_limits<std::uint16_t>::max)()))
         {
             throw influxdb::InfluxDBException("Ill-formed URI, invalid port");
         }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,7 @@ add_unittest(InfluxDBTest DEPENDS InfluxDB)
 add_unittest(InfluxDBFactoryTest DEPENDS InfluxDB)
 add_unittest(ProxyTest DEPENDS InfluxDB)
 add_unittest(HttpTest DEPENDS InfluxDB-Core InfluxDB-Internal InfluxDB-BoostSupport CprMock Threads::Threads)
+add_unittest(UDPTest DEPENDS InfluxDB-Core InfluxDB-Internal InfluxDB-BoostSupport Threads::Threads)
 
 add_unittest(NoBoostSupportTest)
 target_sources(NoBoostSupportTest PRIVATE ${PROJECT_SOURCE_DIR}/src/NoBoostSupport.cxx)
@@ -53,6 +54,7 @@ add_custom_target(unittest PointTest
     COMMAND InfluxDBFactoryTest
     COMMAND ProxyTest
     COMMAND HttpTest
+    COMMAND UDPTest
     COMMAND NoBoostSupportTest
     COMMAND $<$<AND:$<BOOL:${INFLUXCXX_WITH_BOOST}>,$<NOT:$<PLATFORM_ID:Windows>>>:BoostSupportTest>
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,6 +38,7 @@ add_unittest(InfluxDBFactoryTest DEPENDS InfluxDB)
 add_unittest(ProxyTest DEPENDS InfluxDB)
 add_unittest(HttpTest DEPENDS InfluxDB-Core InfluxDB-Internal InfluxDB-BoostSupport CprMock Threads::Threads)
 add_unittest(UDPTest DEPENDS InfluxDB-Core InfluxDB-Internal InfluxDB-BoostSupport Threads::Threads)
+add_unittest(UriParserTest DEPENDS InfluxDB)
 
 add_unittest(NoBoostSupportTest)
 target_sources(NoBoostSupportTest PRIVATE ${PROJECT_SOURCE_DIR}/src/NoBoostSupport.cxx)
@@ -55,6 +56,7 @@ add_custom_target(unittest PointTest
     COMMAND ProxyTest
     COMMAND HttpTest
     COMMAND UDPTest
+    COMMAND UriParserTest
     COMMAND NoBoostSupportTest
     COMMAND $<$<AND:$<BOOL:${INFLUXCXX_WITH_BOOST}>,$<NOT:$<PLATFORM_ID:Windows>>>:BoostSupportTest>
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,11 +33,10 @@ add_unittest(PointTest DEPENDS InfluxDB)
 target_compile_options(PointTest PRIVATE $<$<NOT:$<BOOL:${MSVC}>>:-Wno-deprecated-declarations>)
 
 add_unittest(LineProtocolTest DEPENDS InfluxDB InfluxDB-Internal)
-add_unittest(InfluxDBTest DEPENDS InfluxDB)
+add_unittest(InfluxDBTest DEPENDS InfluxDB InfluxDB-Internal)
 add_unittest(InfluxDBFactoryTest DEPENDS InfluxDB)
 add_unittest(ProxyTest DEPENDS InfluxDB)
 add_unittest(HttpTest DEPENDS InfluxDB-Core InfluxDB-Internal InfluxDB-BoostSupport CprMock Threads::Threads)
-add_unittest(UDPTest DEPENDS InfluxDB-Core InfluxDB-Internal InfluxDB-BoostSupport Threads::Threads)
 add_unittest(UriParserTest DEPENDS InfluxDB)
 
 add_unittest(NoBoostSupportTest)
@@ -46,6 +45,7 @@ target_link_libraries(NoBoostSupportTest PRIVATE InfluxDB)
 
 if (INFLUXCXX_WITH_BOOST)
     add_unittest(BoostSupportTest DEPENDS InfluxDB-BoostSupport InfluxDB Boost::system date::date)
+    add_unittest(UDPTest DEPENDS InfluxDB-BoostSupport InfluxDB Boost::system)
 endif()
 
 
@@ -55,10 +55,10 @@ add_custom_target(unittest PointTest
     COMMAND InfluxDBFactoryTest
     COMMAND ProxyTest
     COMMAND HttpTest
-    COMMAND UDPTest
     COMMAND UriParserTest
     COMMAND NoBoostSupportTest
     COMMAND $<$<AND:$<BOOL:${INFLUXCXX_WITH_BOOST}>,$<NOT:$<PLATFORM_ID:Windows>>>:BoostSupportTest>
+    COMMAND $<$<AND:$<BOOL:${INFLUXCXX_WITH_BOOST}>,$<NOT:$<PLATFORM_ID:Windows>>>:UDPTest>
 
     COMMENT "Running unit tests\n\n"
     VERBATIM

--- a/test/InfluxDBTest.cxx
+++ b/test/InfluxDBTest.cxx
@@ -22,6 +22,7 @@
 
 #include "InfluxDB.h"
 #include "InfluxDBException.h"
+#include "LineProtocol.h"
 #include "mock/TransportMock.h"
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/trompeloeil.hpp>
@@ -184,7 +185,8 @@ namespace influxdb::test
                        }};
         auto FormatPoint{[](const Point& p) -> std::string
                          {
-                             return p.getName() + " " + std::to_string(p.getTimestamp().time_since_epoch().count());
+                             LineProtocol formatter;
+                             return formatter.format(p);
                          }};
 
         Point p1{MakePoint("p1")}, p2{MakePoint("p2")}, p4{MakePoint("p4")};

--- a/test/InfluxDBTest.cxx
+++ b/test/InfluxDBTest.cxx
@@ -32,7 +32,7 @@ namespace influxdb::test
     namespace
     {
         constexpr std::chrono::time_point<std::chrono::system_clock> ignoreTimestamp(std::chrono::milliseconds(4567));
-        constexpr std::size_t unlimitedMessageSize{std::numeric_limits<std::size_t>::max()};
+        constexpr std::size_t unlimitedMessageSize{(std::numeric_limits<std::size_t>::max)()};
     }
 
     TEST_CASE("Ctor throws on nullptr transport", "[InfluxDBTest]")

--- a/test/LineProtocolTest.cxx
+++ b/test/LineProtocolTest.cxx
@@ -58,8 +58,8 @@ namespace influxdb::test
                                .addField("string_value", "abc def ghi")
                                .addField("bool_true_field", true)
                                .addField("bool_false_field", false)
-                               .addField("uint_field", std::numeric_limits<unsigned int>::max())
-                               .addField("ulonglong_field", std::numeric_limits<unsigned long long int>::max())
+                               .addField("uint_field", (std::numeric_limits<unsigned int>::max)())
+                               .addField("ulonglong_field", (std::numeric_limits<unsigned long long int>::max)())
                                .setTimestamp(ignoreTimestamp);
 
         const LineProtocol lineProtocol;

--- a/test/NoBoostSupportTest.cxx
+++ b/test/NoBoostSupportTest.cxx
@@ -36,7 +36,7 @@ namespace influxdb::test
 
             std::size_t getMaxMessageSize() const override
             {
-                return std::numeric_limits<std::size_t>::max();
+                return (std::numeric_limits<std::size_t>::max)();
             }
         };
 

--- a/test/NoBoostSupportTest.cxx
+++ b/test/NoBoostSupportTest.cxx
@@ -33,6 +33,11 @@ namespace influxdb::test
             void send([[maybe_unused]] std::string&& message) override
             {
             }
+
+            std::size_t getMaxMessageSize() const override
+            {
+                return std::numeric_limits<std::size_t>::max();
+            }
         };
 
         TransportDummy dummy;

--- a/test/PointTest.cxx
+++ b/test/PointTest.cxx
@@ -57,8 +57,8 @@ namespace influxdb::test
                                .addField("double_field", double{3.859})
                                .addField("bool_true_field", true)
                                .addField("bool_false_field", false)
-                               .addField("uint_field", std::numeric_limits<unsigned int>::max())
-                               .addField("ulonglong_field", std::numeric_limits<unsigned long long int>::max());
+                               .addField("uint_field", (std::numeric_limits<unsigned int>::max)())
+                               .addField("ulonglong_field", (std::numeric_limits<unsigned long long int>::max)());
 
         // Set float precision to default for this test to ensure the expected double field value
         Point::floatsPrecision = defaultFloatsPrecision;
@@ -208,8 +208,8 @@ namespace influxdb::test
                                .addField("double_field", 1.81)
                                .addField("bool_true_field", true)
                                .addField("bool_false_field", false)
-                               .addField("uint_field", std::numeric_limits<unsigned int>::max())
-                               .addField("ulonglong_field", std::numeric_limits<unsigned long long int>::max())
+                               .addField("uint_field", (std::numeric_limits<unsigned int>::max)())
+                               .addField("ulonglong_field", (std::numeric_limits<unsigned long long int>::max)())
                                .setTimestamp(ignoreTimestamp);
 
         CHECK_THAT(point.toLineProtocol(), Equals("test int_field=12i,"

--- a/test/UDPTest.cxx
+++ b/test/UDPTest.cxx
@@ -32,7 +32,7 @@ namespace influxdb::test
     using influxdb::transports::UDP;
     using Catch::Matchers::ContainsSubstring;
 
-    constexpr int DEFAULT_UDP_PORT{8089};
+    constexpr std::uint16_t DEFAULT_UDP_PORT{8089};
 
     UDP createUDP()
     {

--- a/test/UDPTest.cxx
+++ b/test/UDPTest.cxx
@@ -25,12 +25,11 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
-#include <catch2/trompeloeil.hpp>
 
 namespace influxdb::test
 {
-    using influxdb::transports::UDP;
     using Catch::Matchers::ContainsSubstring;
+    using influxdb::transports::UDP;
 
     constexpr std::uint16_t DEFAULT_UDP_PORT{8089};
     // UDP port to use for test purposes

--- a/test/UDPTest.cxx
+++ b/test/UDPTest.cxx
@@ -1,0 +1,52 @@
+// MIT License
+//
+// Copyright (c) 2020-2023 offa
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "UDP.h"
+#include "InfluxDBException.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <catch2/trompeloeil.hpp>
+
+namespace influxdb::test
+{
+    using influxdb::transports::UDP;
+    using Catch::Matchers::ContainsSubstring;
+
+    constexpr int DEFAULT_UDP_PORT{8089};
+
+    UDP createUDP()
+    {
+        return UDP{"localhost", DEFAULT_UDP_PORT};
+    }
+
+    TEST_CASE("Construction succeeds with resolvable host", "[UDPTest]")
+    {
+        REQUIRE_NOTHROW(createUDP());
+    }
+
+    TEST_CASE("Construction fails on name resolution error", "[UDPTest]")
+    {
+        // RFC2606 ".invalid" TLD should not resolve
+        REQUIRE_THROWS_AS(UDP("hostname.invalid", DEFAULT_UDP_PORT), InfluxDBException);
+    }
+}

--- a/test/UriParserTest.cxx
+++ b/test/UriParserTest.cxx
@@ -1,0 +1,93 @@
+// MIT License
+//
+// Copyright (c) 2020-2023 offa
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "UriParser.h"
+#include "InfluxDBException.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <catch2/trompeloeil.hpp>
+
+namespace influxdb::test
+{
+    using http::ParseHttpUrl;
+
+    TEST_CASE("Valid URI", "[UriParserTest]")
+    {
+        std::string urlString{"https://username:password@localhost:8086/path?search"};
+        const auto url{ParseHttpUrl(urlString)};
+        REQUIRE(url.protocol == "https");
+        REQUIRE(url.user == "username");
+        REQUIRE(url.password == "password");
+        REQUIRE(url.host == "localhost");
+        REQUIRE(url.port == 8086);
+        REQUIRE(url.path == "/path");
+        REQUIRE(url.search == "search");
+    }
+
+    TEST_CASE("Missing protocol", "[UriParserTest]")
+    {
+        std::string missingProtocol{"username:password@localhost:8086/path?search"};
+        CHECK_THROWS_AS(ParseHttpUrl(missingProtocol), InfluxDBException);
+    }
+
+    TEST_CASE("No port", "[UriParserTest]")
+    {
+        std::string noPort{"http://localhost/db=dbname"};
+        const auto url{ParseHttpUrl(noPort)};
+        REQUIRE(url.protocol == "http");
+        REQUIRE(url.user == "");
+        REQUIRE(url.password == "");
+        REQUIRE(url.host == "localhost");
+        REQUIRE(url.port == http::url::PORT_NOT_SET);
+        REQUIRE(url.path == "/db=dbname");
+        REQUIRE(url.search == "");
+    }
+
+    TEST_CASE("Invalid port", "[UriParserTest]") {
+        std::string colonButNoNumber{"udp://localhost:twelve"};
+        CHECK_THROWS_AS(ParseHttpUrl(colonButNoNumber), InfluxDBException);
+    }
+
+    TEST_CASE("Minimum valid port", "[UriParserTest]")
+    {
+        std::string zeroPort{"udp://localhost:0"};
+        const auto url{ParseHttpUrl(zeroPort)};
+        REQUIRE(url.port == 0);
+    }
+
+    TEST_CASE("Maximum valid port", "[UriParserTest]")
+    {
+        std::string maxPort{"udp://localhost:65535"};
+        const auto url{ParseHttpUrl(maxPort)};
+        REQUIRE(url.port == 65535);
+    }
+
+    TEST_CASE("Out of range port", "[UriParserTest]")
+    {
+        std::string negativePort{"udp://localhost:-1"};
+        CHECK_THROWS_AS(ParseHttpUrl(negativePort), InfluxDBException);
+        std::string tooLargePort{"udp://localhost:65536"};
+        CHECK_THROWS_AS(ParseHttpUrl(negativePort), InfluxDBException);
+    }
+
+}

--- a/test/UriParserTest.cxx
+++ b/test/UriParserTest.cxx
@@ -63,7 +63,8 @@ namespace influxdb::test
         REQUIRE(url.search == "");
     }
 
-    TEST_CASE("Invalid port", "[UriParserTest]") {
+    TEST_CASE("Invalid port", "[UriParserTest]")
+    {
         std::string colonButNoNumber{"udp://localhost:twelve"};
         CHECK_THROWS_AS(ParseHttpUrl(colonButNoNumber), InfluxDBException);
     }

--- a/test/mock/TransportMock.h
+++ b/test/mock/TransportMock.h
@@ -31,6 +31,7 @@ namespace influxdb::test
     class TransportMock : public Transport
     {
         MAKE_MOCK1(send, void(std::string&&), override);
+        MAKE_MOCK0(getMaxMessageSize, std::size_t(), const override);
         MAKE_MOCK1(query, std::string(const std::string&), override);
         MAKE_MOCK0(createDatabase, void(), override);
         MAKE_MOCK1(execute, std::string(const std::string&), override);
@@ -48,6 +49,11 @@ namespace influxdb::test
         void send(std::string&& message) override
         {
             mockImpl->send(std::move(message));
+        }
+
+        std::size_t getMaxMessageSize() const override
+        {
+            return mockImpl->getMaxMessageSize();
         }
 
         std::string query(const std::string& query) override

--- a/test/system/InfluxDBST.cxx
+++ b/test/system/InfluxDBST.cxx
@@ -304,7 +304,7 @@ namespace influxdb::test
                 udpTransport->write(Point{measurement}.addField("f" + std::to_string(i), kiloStr).addTag("type", "udp_batching"));
             }
             // Force flush
-            udpTransport->flushBatch();
+            CHECK_NOTHROW(udpTransport->flushBatch());
             // Check all points are written
             WaitForUDPBatchTimeout();
             CHECK(querySize(*httpTransport, "udp_batching") == numPoints);

--- a/test/system/InfluxDBST.cxx
+++ b/test/system/InfluxDBST.cxx
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#include <thread>
 #include "SystemTest.h"
 
 namespace influxdb::test
@@ -251,12 +252,67 @@ namespace influxdb::test
             const Point::FieldSet& fields{point.getFieldSet()};
             // String fields are put in the tags (see above)
             CHECK(fields.size() == 0);
-        }
-
-        SECTION("Cleanup")
-        {
             db->execute("drop database " + dbName);
         }
     }
 
+    TEST_CASE("UDP Transport", "[InfluxDBST]")
+    {
+        using namespace Catch::Matchers;
+
+        const std::string dbName{"st_udp"};
+        // UDP transport for writing points
+        auto udpTransport{configure(dbName, std::nullopt, "udp", 8089)};
+        // HTTP transport for running queries
+        auto httpTransport{configure(dbName, std::nullopt, "http", 8086)};
+
+        const std::string measurement{"x"};
+
+        // Configured via INFLUXDB_UDP_BATCH_TIMEOUT in systemtest.yml
+        static constexpr std::chrono::milliseconds INFLUXDB_BATCH_TIMEOUT{10};
+        auto WaitForUDPBatchTimeout{[]()
+                                    {
+                                        // Make sure the batch is flushed
+                                        std::this_thread::sleep_for(10 * INFLUXDB_BATCH_TIMEOUT);
+                                    }};
+
+        SECTION("Create database")
+        {
+            httpTransport->createDatabaseIfNotExists();
+        }
+
+        SECTION("Write single point")
+        {
+            CHECK(querySize(*httpTransport, "sp") == 0);
+            udpTransport->write(Point{measurement}.addField("n", 0).addTag("type", "sp"));
+            WaitForUDPBatchTimeout();
+            CHECK(querySize(*httpTransport, "sp") == 1);
+        }
+
+        SECTION("UDP batch flush is aware of UDP packet size limit")
+        {
+            // 1KB string
+            static const std::string kiloStr(std::size_t{1024}, 'k');
+
+            CHECK(querySize(*httpTransport, "udp_batching") == 0);
+            // Add 64 points with 1KB string (too large for a single UDP packet)
+            constexpr std::size_t numPoints{64};
+            // Enable batching (enough that all points will be written in a single batch)
+            udpTransport->batchOf(numPoints + 1);
+            for (std::size_t i{0}; i < numPoints; ++i)
+            {
+                udpTransport->write(Point{measurement}.addField("f" + std::to_string(i), kiloStr).addTag("type", "udp_batching"));
+            }
+            // Force flush
+            udpTransport->flushBatch();
+            // Check all points are written
+            WaitForUDPBatchTimeout();
+            CHECK(querySize(*httpTransport, "udp_batching") == numPoints);
+        }
+
+        SECTION("Cleanup")
+        {
+            httpTransport->execute("drop database " + dbName);
+        }
+    }
 }

--- a/test/system/InfluxDBST.cxx
+++ b/test/system/InfluxDBST.cxx
@@ -272,8 +272,10 @@ namespace influxdb::test
         static constexpr std::chrono::milliseconds INFLUXDB_BATCH_TIMEOUT{10};
         auto WaitForUDPBatchTimeout{[]()
                                     {
-                                        // Make sure the batch is flushed
-                                        std::this_thread::sleep_for(10 * INFLUXDB_BATCH_TIMEOUT);
+                                        // Influx flushes points received over UDP at a configurable interval
+                                        // however, local testing show this to be somewhat unreliable.
+                                        // Therefore, we wait considerably longer than the configured interval.
+                                        std::this_thread::sleep_for(20 * INFLUXDB_BATCH_TIMEOUT);
                                     }};
 
         SECTION("Create database")

--- a/test/system/SystemTest.h
+++ b/test/system/SystemTest.h
@@ -61,10 +61,13 @@ namespace influxdb::test
         return {*user, *pass};
     }
 
-    inline std::unique_ptr<InfluxDB> configure(const std::string& db, std::optional<User> user = {})
+    inline std::unique_ptr<InfluxDB> configure(const std::string& db,
+                                               std::optional<User> user = {},
+                                               const std::string& protocol = "http",
+                                               std::uint16_t port = 8086)
     {
         const auto host = getEnv("INFLUXDBCXX_SYSTEMTEST_HOST").value_or("localhost");
         const std::string authString{user ? (user->name + ":" + user->pass + "@") : ""};
-        return InfluxDBFactory::Get("http://" + authString + host + ":8086?db=" + db);
+        return InfluxDBFactory::Get(protocol + "://" + authString + host + ":" + std::to_string(port) + "?db=" + db);
     }
 }


### PR DESCRIPTION
This closes #184.

Adds a new mandatory member function of the `Transport` base class called `getMaxMessageSize`. This function must returns the size of the maximum message which may be transmitted using the Transport implementation's `send` method.
- For the `UDP` transport this is set to the minimum of the UDP socket's send buffer (for [MacOS](https://developer.apple.com/forums/thread/74655)) or the maximum data [length](https://en.wikipedia.org/wiki/User_Datagram_Protocol#UDP_datagram_structure) which is practical in the UDP protocol after header sizes are taken into account (`65507`). 
**N.B.** This may cause packet fragmentation at the IP layer but since UDP makes no delivery guarantees anyway I think this is an acceptable compromise when the user has chosen to batch write points over UDP.
- For the other transports (`HTTP`, `TCP`, `UnixSocket`) this is to effectively unlimited (`std::numeric_limits<std::size_t>::max()`) to preserve existing behaviour.


The `InfluxDB::flushBatch` method is updated to construct the largest possible messages which can be successfully sent given the `mTransport` in use.

If any individual Point is too large to be successfully sent (i.e.: its Line Protocol representation is larger than the maximum message size) it is skipped and the other Points in the batch are sent. An exception is subsequently raised.