### PR TITLE
Add additional error information to HTTP exceptions

### DIFF
--- a/src/HTTP.cxx
+++ b/src/HTTP.cxx
@@ -41,7 +41,7 @@ namespace influxdb::transports
             }
             if (!cpr::status::is_success(resp.status_code))
             {
-                throw InfluxDBException{"Request failed: (" + std::to_string(resp.status_code) + ") " + resp.reason};
+                throw InfluxDBException{"Request failed: (" + std::to_string(resp.status_code) + ") " + resp.reason + " (message: '" + resp.text + "')"};
             }
         }
 


### PR DESCRIPTION
Adds additional information to the exception message (#208, #161).

> Request failed: (400) Bad Request

becomes

> Request failed: (400) Bad Request (message: {"error":"partial write: field
  type conflict: input field \"value\" on measurement \"x\" is type string,
  already exists as type integer dropped=1"}
  )
