### PR TITLE
Remove deprecated InfluxDB::flushBuffer() and InfluxDBException ctor

### DIFF
--- a/include/InfluxDB.h
+++ b/include/InfluxDB.h
@@ -70,12 +70,6 @@ namespace influxdb
         /// Flushes points batched (this can also happens when buffer is full)
         void flushBatch();
 
-        /// \deprecated use \ref flushBatch() instead - will be removed in v0.8.0
-        [[deprecated("Use flushBatch() instead - will be removed in v0.8.0")]] inline void flushBuffer()
-        {
-            flushBatch();
-        }
-
         /// Enables points batching
         /// \param size
         void batchOf(std::size_t size = 32);

--- a/include/InfluxDBException.h
+++ b/include/InfluxDBException.h
@@ -39,13 +39,6 @@ namespace influxdb
     class INFLUXDB_EXPORT InfluxDBException : public std::runtime_error
     {
     public:
-        /// \deprecated Use InfluxDBException(const std::string&) instead - will be removed in v0.8.0
-        [[deprecated("Use InfluxDBException(const std::string&) instead - will be removed in v0.8.0")]] InfluxDBException(const std::string& source, const std::string& message)
-            : std::runtime_error::runtime_error(
-                  "influx-cxx [" + source + "]: " + message)
-        {
-        }
-
         explicit InfluxDBException(const std::string& message)
             : std::runtime_error::runtime_error(message)
         {


### PR DESCRIPTION
Part of #165.