### PR TITLE
Fix Python and Boost CI installation issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,9 @@ jobs:
       - name: Install Boost
         if: ${{ matrix.boost == true }}
         run: |
-          add-apt-repository ppa:nicola-onorata/toolchain
+          add-apt-repository ppa:mhier/libboost-latest
           apt-get update
-          apt-get install -y boost1.81
+          apt-get install -y boost1.83
       - name: Build
         run: script/ci_build.sh -DINFLUXCXX_WITH_BOOST=${{ matrix.boost }}
       - name: Check deployment as cmake subdirectory

--- a/.github/workflows/systemtest.yml
+++ b/.github/workflows/systemtest.yml
@@ -36,9 +36,9 @@ jobs:
       - name: Setup
         run: |
           script/ci_setup.sh
-          add-apt-repository ppa:nicola-onorata/toolchain
+          add-apt-repository ppa:mhier/libboost-latest
           apt-get update
-          apt-get install -y boost1.81
+          apt-get install -y boost1.83
       - name: Build
         run: |
           cmake --preset conan-release

--- a/script/ci_setup.sh
+++ b/script/ci_setup.sh
@@ -2,13 +2,14 @@
 
 set -ex
 
+export DEBIAN_FRONTEND=noninteractive
+export PATH=$HOME/.local/bin:$PATH
 apt-get update
-apt-get install -y python3-pip libssl-dev libcurl4-openssl-dev
-pip3 install -U conan
+apt-get install -y pipx
+pipx install conan
+conan profile detect
 
 mkdir -p build && cd build
-
-conan profile detect
 
 if [[ "${CXX}" == clang* ]]
 then

--- a/script/ci_testdeploy.sh
+++ b/script/ci_testdeploy.sh
@@ -5,6 +5,7 @@ set -ex
 PID=$$
 BASEPATH=/tmp/influx-test-${PID}
 BUILD_TYPE="Release"
+export PATH=$HOME/.local/bin:$PATH
 
 echo "perform deployment test in ${BASEPATH}"
 mkdir -p ${BASEPATH}/influxdb-cxx


### PR DESCRIPTION
Use pipx instead of pip and replace the Boost PPA to fix CI builds (#254).