### PR TITLE
Move public API Header to InfluxDB/ subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/cmake/InfluxDBConf
 
 # Install headers
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
-install(FILES ${PROJECT_BINARY_DIR}/src/influxdb_export.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(FILES ${PROJECT_BINARY_DIR}/src/InfluxDB/influxdb_export.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/InfluxDB")
 
 # Export targets
 install(EXPORT InfluxDBTargets

--- a/include/InfluxDB/InfluxDB.h
+++ b/include/InfluxDB/InfluxDB.h
@@ -34,9 +34,9 @@
 #include <vector>
 #include <deque>
 
-#include "Transport.h"
-#include "Point.h"
-#include "influxdb_export.h"
+#include "InfluxDB/Transport.h"
+#include "InfluxDB/Point.h"
+#include "InfluxDB/influxdb_export.h"
 
 namespace influxdb
 {

--- a/include/InfluxDB/InfluxDBBuilder.h
+++ b/include/InfluxDB/InfluxDBBuilder.h
@@ -23,10 +23,10 @@
 #ifndef INFLUXDATA_INFLUXDBBUILDER_H
 #define INFLUXDATA_INFLUXDBBUILDER_H
 
-#include "InfluxDB.h"
-#include "Transport.h"
-#include "Proxy.h"
-#include "influxdb_export.h"
+#include "InfluxDB/InfluxDB.h"
+#include "InfluxDB/Transport.h"
+#include "InfluxDB/Proxy.h"
+#include "InfluxDB/influxdb_export.h"
 #include <chrono>
 
 namespace influxdb

--- a/include/InfluxDB/InfluxDBException.h
+++ b/include/InfluxDB/InfluxDBException.h
@@ -31,7 +31,7 @@
 #include <stdexcept>
 #include <string>
 
-#include "influxdb_export.h"
+#include "InfluxDB/influxdb_export.h"
 
 namespace influxdb
 {

--- a/include/InfluxDB/InfluxDBFactory.h
+++ b/include/InfluxDB/InfluxDBFactory.h
@@ -28,9 +28,9 @@
 #ifndef INFLUXDATA_INFLUXDB_FACTORY_H
 #define INFLUXDATA_INFLUXDB_FACTORY_H
 
-#include "InfluxDB.h"
-#include "Transport.h"
-#include "influxdb_export.h"
+#include "InfluxDB/InfluxDB.h"
+#include "InfluxDB/Transport.h"
+#include "InfluxDB/influxdb_export.h"
 
 namespace influxdb
 {

--- a/include/InfluxDB/Point.h
+++ b/include/InfluxDB/Point.h
@@ -34,7 +34,7 @@
 #include <variant>
 #include <deque>
 
-#include "influxdb_export.h"
+#include "InfluxDB/influxdb_export.h"
 
 namespace influxdb
 {

--- a/include/InfluxDB/Proxy.h
+++ b/include/InfluxDB/Proxy.h
@@ -23,7 +23,7 @@
 #ifndef INFLUXDATA_PROXY_H
 #define INFLUXDATA_PROXY_H
 
-#include "influxdb_export.h"
+#include "InfluxDB/influxdb_export.h"
 #include <string>
 #include <optional>
 

--- a/include/InfluxDB/Transport.h
+++ b/include/InfluxDB/Transport.h
@@ -28,9 +28,9 @@
 #ifndef INFLUXDATA_TRANSPORTINTERFACE_H
 #define INFLUXDATA_TRANSPORTINTERFACE_H
 
-#include "InfluxDBException.h"
-#include "influxdb_export.h"
-#include "Proxy.h"
+#include "InfluxDB/InfluxDBException.h"
+#include "InfluxDB/influxdb_export.h"
+#include "InfluxDB/Proxy.h"
 
 namespace influxdb
 {

--- a/script/include_library/main.cxx
+++ b/script/include_library/main.cxx
@@ -1,5 +1,5 @@
 // Sample project to check if the deployment process works
-#include <InfluxDBFactory.h>
+#include <InfluxDB/InfluxDBFactory.h>
 
 int main()
 {

--- a/src/BoostSupport.h
+++ b/src/BoostSupport.h
@@ -23,8 +23,8 @@
 
 #pragma once
 
-#include "Transport.h"
-#include "Point.h"
+#include "InfluxDB/Transport.h"
+#include "InfluxDB/Point.h"
 #include "UriParser.h"
 #include <memory>
 #include <string>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,7 +68,7 @@ set_target_properties(InfluxDB PROPERTIES
   SOVERSION ${SO_VERSION_MAJOR}
 )
 
-generate_export_header(InfluxDB)
+generate_export_header(InfluxDB EXPORT_FILE_NAME "${PROJECT_BINARY_DIR}/src/InfluxDB/influxdb_export.h")
 
 target_include_directories(InfluxDB
   PUBLIC

--- a/src/HTTP.cxx
+++ b/src/HTTP.cxx
@@ -26,7 +26,7 @@
 ///
 
 #include "HTTP.h"
-#include "InfluxDBException.h"
+#include "InfluxDB/InfluxDBException.h"
 
 namespace influxdb::transports
 {

--- a/src/HTTP.h
+++ b/src/HTTP.h
@@ -28,7 +28,7 @@
 #ifndef INFLUXDATA_TRANSPORTS_HTTP_H
 #define INFLUXDATA_TRANSPORTS_HTTP_H
 
-#include "Transport.h"
+#include "InfluxDB/Transport.h"
 #include <memory>
 #include <string>
 #include <chrono>

--- a/src/InfluxDB.cxx
+++ b/src/InfluxDB.cxx
@@ -25,8 +25,8 @@
 /// \author Adam Wegrzynek <adam.wegrzynek@cern.ch>
 ///
 
-#include "InfluxDB.h"
-#include "InfluxDBException.h"
+#include "InfluxDB/InfluxDB.h"
+#include "InfluxDB/InfluxDBException.h"
 #include "LineProtocol.h"
 #include "BoostSupport.h"
 #include <iostream>

--- a/src/InfluxDBBuilder.cxx
+++ b/src/InfluxDBBuilder.cxx
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#include "InfluxDBBuilder.h"
+#include "InfluxDB/InfluxDBBuilder.h"
 #include "HTTP.h"
 
 namespace influxdb

--- a/src/InfluxDBFactory.cxx
+++ b/src/InfluxDBFactory.cxx
@@ -25,14 +25,14 @@
 /// \author Adam Wegrzynek <adam.wegrzynek@cern.ch>
 ///
 
-#include "InfluxDBFactory.h"
+#include "InfluxDB/InfluxDBFactory.h"
 #include <functional>
 #include <string>
 #include <memory>
 #include <map>
+#include "InfluxDB/InfluxDBException.h"
 #include "UriParser.h"
 #include "HTTP.h"
-#include "InfluxDBException.h"
 #include "BoostSupport.h"
 
 namespace influxdb

--- a/src/LineProtocol.h
+++ b/src/LineProtocol.h
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include "Point.h"
+#include "InfluxDB/Point.h"
 
 #include <string>
 

--- a/src/NoBoostSupport.cxx
+++ b/src/NoBoostSupport.cxx
@@ -22,7 +22,7 @@
 // SOFTWARE.
 
 #include "BoostSupport.h"
-#include "InfluxDBException.h"
+#include "InfluxDB/InfluxDBException.h"
 
 namespace influxdb::internal
 {

--- a/src/Point.cxx
+++ b/src/Point.cxx
@@ -25,7 +25,7 @@
 /// \author Adam Wegrzynek <adam.wegrzynek@cern.ch>
 ///
 
-#include "Point.h"
+#include "InfluxDB/Point.h"
 #include <chrono>
 #include <memory>
 #include <sstream>

--- a/src/Proxy.cxx
+++ b/src/Proxy.cxx
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#include "Proxy.h"
+#include "InfluxDB/Proxy.h"
 
 namespace influxdb
 {

--- a/src/TCP.cxx
+++ b/src/TCP.cxx
@@ -25,7 +25,7 @@
 ///
 
 #include "TCP.h"
-#include "InfluxDBException.h"
+#include "InfluxDB/InfluxDBException.h"
 #include <string>
 
 namespace influxdb::transports

--- a/src/TCP.h
+++ b/src/TCP.h
@@ -27,7 +27,7 @@
 #ifndef INFLUXDATA_TRANSPORTS_TCP_H
 #define INFLUXDATA_TRANSPORTS_TCP_H
 
-#include "Transport.h"
+#include "InfluxDB/Transport.h"
 
 #include <boost/asio.hpp>
 #include <chrono>

--- a/src/UDP.cxx
+++ b/src/UDP.cxx
@@ -26,7 +26,7 @@
 ///
 
 #include "UDP.h"
-#include "InfluxDBException.h"
+#include "InfluxDB/InfluxDBException.h"
 #include <string>
 
 namespace influxdb::transports

--- a/src/UDP.h
+++ b/src/UDP.h
@@ -28,7 +28,7 @@
 #ifndef INFLUXDATA_TRANSPORTS_UDP_H
 #define INFLUXDATA_TRANSPORTS_UDP_H
 
-#include "Transport.h"
+#include "InfluxDB/Transport.h"
 
 #include <boost/asio.hpp>
 #include <chrono>

--- a/src/UnixSocket.cxx
+++ b/src/UnixSocket.cxx
@@ -26,7 +26,7 @@
 ///
 
 #include "UnixSocket.h"
-#include "InfluxDBException.h"
+#include "InfluxDB/InfluxDBException.h"
 #include <string>
 
 namespace influxdb::transports

--- a/src/UnixSocket.h
+++ b/src/UnixSocket.h
@@ -28,7 +28,7 @@
 #ifndef INFLUXDATA_TRANSPORTS_UNIX_H
 #define INFLUXDATA_TRANSPORTS_UNIX_H
 
-#include "Transport.h"
+#include "InfluxDB/Transport.h"
 
 #include <boost/asio.hpp>
 #include <string>

--- a/test/BoostSupportTest.cxx
+++ b/test/BoostSupportTest.cxx
@@ -21,7 +21,7 @@
 // SOFTWARE.
 
 #include "BoostSupport.h"
-#include "InfluxDBException.h"
+#include "InfluxDB/InfluxDBException.h"
 #include "mock/TransportMock.h"
 #include <boost/property_tree/exceptions.hpp>
 #include <catch2/catch_test_macros.hpp>

--- a/test/HttpTest.cxx
+++ b/test/HttpTest.cxx
@@ -21,7 +21,7 @@
 // SOFTWARE.
 
 #include "HTTP.h"
-#include "InfluxDBException.h"
+#include "InfluxDB/InfluxDBException.h"
 #include "mock/CprMock.h"
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/trompeloeil.hpp>

--- a/test/InfluxDBFactoryTest.cxx
+++ b/test/InfluxDBFactoryTest.cxx
@@ -20,8 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#include "InfluxDBFactory.h"
-#include "InfluxDBException.h"
+#include "InfluxDB/InfluxDBFactory.h"
+#include "InfluxDB/InfluxDBException.h"
 #include <catch2/catch_test_macros.hpp>
 
 namespace influxdb::test

--- a/test/InfluxDBTest.cxx
+++ b/test/InfluxDBTest.cxx
@@ -20,8 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#include "InfluxDB.h"
-#include "InfluxDBException.h"
+#include "InfluxDB/InfluxDB.h"
+#include "InfluxDB/InfluxDBException.h"
 #include "mock/TransportMock.h"
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/trompeloeil.hpp>

--- a/test/NoBoostSupportTest.cxx
+++ b/test/NoBoostSupportTest.cxx
@@ -21,7 +21,7 @@
 // SOFTWARE.
 
 #include "BoostSupport.h"
-#include "InfluxDBException.h"
+#include "InfluxDB/InfluxDBException.h"
 #include <catch2/catch_test_macros.hpp>
 
 namespace influxdb::test

--- a/test/PointTest.cxx
+++ b/test/PointTest.cxx
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#include "Point.h"
+#include "InfluxDB/Point.h"
 #include <limits>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_all.hpp>

--- a/test/ProxyTest.cxx
+++ b/test/ProxyTest.cxx
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#include "Proxy.h"
+#include "InfluxDB/Proxy.h"
 #include <catch2/matchers/catch_matchers_all.hpp>
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/mock/TransportMock.h
+++ b/test/mock/TransportMock.h
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include "Transport.h"
+#include "InfluxDB/Transport.h"
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/trompeloeil.hpp>
 

--- a/test/system/HttpAuthST.cxx
+++ b/test/system/HttpAuthST.cxx
@@ -21,7 +21,7 @@
 // SOFTWARE.
 
 #include "SystemTest.h"
-#include "InfluxDBBuilder.h"
+#include "InfluxDB/InfluxDBBuilder.h"
 
 namespace influxdb::test
 {

--- a/test/system/InfluxDBST.cxx
+++ b/test/system/InfluxDBST.cxx
@@ -21,7 +21,7 @@
 // SOFTWARE.
 
 #include "SystemTest.h"
-#include "InfluxDBBuilder.h"
+#include "InfluxDB/InfluxDBBuilder.h"
 
 namespace influxdb::test
 {

--- a/test/system/SystemTest.h
+++ b/test/system/SystemTest.h
@@ -22,8 +22,8 @@
 
 #pragma once
 
-#include "InfluxDBFactory.h"
-#include "InfluxDBException.h"
+#include "InfluxDB/InfluxDBFactory.h"
+#include "InfluxDB/InfluxDBException.h"
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_all.hpp>
 #include <string>

--- a/test_package/example.cpp
+++ b/test_package/example.cpp
@@ -1,4 +1,4 @@
-#include <InfluxDBFactory.h>
+#include <InfluxDB/InfluxDBFactory.h>
 
 int main()
 {


### PR DESCRIPTION
Moves all public API headers to `InfluxDB/` subdirectory to avoid conflicts with other libraries (#263).