### PR TITLE
Install public API Header to InfluxDB/ subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ option(INFLUXCXX_WITH_BOOST "Build with Boost support enabled" ON)
 option(INFLUXCXX_TESTING "Enable testing for this component" ON)
 option(INFLUXCXX_SYSTEMTEST "Enable system tests" ON)
 option(INFLUXCXX_COVERAGE "Enable Coverage" OFF)
+option(INFLUXCXX_INSTALL_HEADER_TO_SUBDIR "Install header to InfluxDB/ subdir - will be default in 0.8.0" OFF)
 
 # Define project
 project(influxdb-cxx
@@ -69,6 +70,11 @@ message(STATUS "Boost support : ${INFLUXCXX_WITH_BOOST}")
 message(STATUS "Unit Tests : ${INFLUXCXX_TESTING}")
 message(STATUS "System Tests : ${INFLUXCXX_SYSTEMTEST}")
 
+set(HEADER_INSTALL_SUBDIR "")
+
+if (INFLUXCXX_INSTALL_HEADER_TO_SUBDIR)
+  set(HEADER_INSTALL_SUBDIR "InfluxDB")
+endif()
 
 # Add coverage flags
 if(INFLUXCXX_COVERAGE)
@@ -149,8 +155,8 @@ write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/cmake/InfluxDBConf
 )
 
 # Install headers
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/InfluxDB")
-install(FILES ${PROJECT_BINARY_DIR}/src/influxdb_export.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/InfluxDB")
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${HEADER_INSTALL_SUBDIR}")
+install(FILES ${PROJECT_BINARY_DIR}/src/influxdb_export.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${HEADER_INSTALL_SUBDIR}")
 
 # Export targets
 install(EXPORT InfluxDBTargets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,8 +149,8 @@ write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/cmake/InfluxDBConf
 )
 
 # Install headers
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
-install(FILES ${PROJECT_BINARY_DIR}/src/influxdb_export.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/InfluxDB")
+install(FILES ${PROJECT_BINARY_DIR}/src/influxdb_export.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/InfluxDB")
 
 # Export targets
 install(EXPORT InfluxDBTargets

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,7 +71,7 @@ generate_export_header(InfluxDB)
 
 target_include_directories(InfluxDB
   PUBLIC
-    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:include/InfluxDB>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     # for export header
     $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,7 +71,7 @@ generate_export_header(InfluxDB)
 
 target_include_directories(InfluxDB
   PUBLIC
-    $<INSTALL_INTERFACE:include/InfluxDB>
+    $<INSTALL_INTERFACE:include/${HEADER_INSTALL_SUBDIR}>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     # for export header
     $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src>


### PR DESCRIPTION
Less intrusive adaption of #264 (#222).

Headers are installed into `include/InfluxDB/`, but no `#include` changes are necessary.