### PR TITLE
Boost 1.87 compatibility

### DIFF
--- a/src/TCP.h
+++ b/src/TCP.h
@@ -54,7 +54,7 @@ namespace influxdb::transports
 
     private:
         /// Boost Asio I/O functionality
-        boost::asio::io_service mIoService;
+        boost::asio::io_context mIoContext;
 
         /// TCP socket
         boost::asio::ip::tcp::socket mSocket;

--- a/src/UDP.cxx
+++ b/src/UDP.cxx
@@ -33,12 +33,15 @@ namespace influxdb::transports
 {
 
     UDP::UDP(const std::string& hostname, int port)
-        : mSocket(mIoService, boost::asio::ip::udp::endpoint(boost::asio::ip::udp::v4(), 0))
+        : mSocket(mIoContext, boost::asio::ip::udp::endpoint(boost::asio::ip::udp::v4(), 0))
     {
-        boost::asio::ip::udp::resolver resolver(mIoService);
-        boost::asio::ip::udp::resolver::query query(boost::asio::ip::udp::v4(), hostname, std::to_string(port));
-        boost::asio::ip::udp::resolver::iterator resolverInerator = resolver.resolve(query);
-        mEndpoint = *resolverInerator;
+        boost::asio::ip::udp::resolver resolver(mIoContext);
+        mEndpoint = *(resolver
+                          .resolve(boost::asio::ip::udp::v4(),
+                                   hostname,
+                                   std::to_string(port),
+                                   boost::asio::ip::resolver_query_base::passive)
+                          .cbegin());
     }
 
     void UDP::send(std::string&& message)

--- a/src/UDP.h
+++ b/src/UDP.h
@@ -49,7 +49,7 @@ namespace influxdb::transports
 
     private:
         /// Boost Asio I/O functionality
-        boost::asio::io_service mIoService;
+        boost::asio::io_context mIoContext;
 
         /// UDP socket
         boost::asio::ip::udp::socket mSocket;

--- a/src/UnixSocket.cxx
+++ b/src/UnixSocket.cxx
@@ -34,7 +34,7 @@ namespace influxdb::transports
 #if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
 
     UnixSocket::UnixSocket(const std::string& socketPath)
-        : mSocket(mIoService), mEndpoint(socketPath)
+        : mSocket(mIoContext), mEndpoint(socketPath)
     {
         mSocket.open();
     }

--- a/src/UnixSocket.h
+++ b/src/UnixSocket.h
@@ -47,7 +47,7 @@ namespace influxdb::transports
 
     private:
         /// Boost Asio I/O functionality
-        boost::asio::io_service mIoService;
+        boost::asio::io_context mIoContext;
 #if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
         /// Unix socket
         boost::asio::local::datagram_protocol::socket mSocket;


### PR DESCRIPTION
Replaces deprecated Boost Asio APIs that were removed in version 1.87.