### PR TITLE
Use defined precision timestamps internally

### DIFF
--- a/include/InfluxDB/Point.h
+++ b/include/InfluxDB/Point.h
@@ -56,13 +56,13 @@ namespace influxdb
         Point&& addField(std::string_view name, const FieldValue& value);
 
         /// Sets custom timestamp
-        Point&& setTimestamp(std::chrono::time_point<std::chrono::system_clock> timestamp);
+        Point&& setTimestamp(std::chrono::sys_time<std::chrono::nanoseconds> timestamp);
 
         /// Name getter
         std::string getName() const;
 
         /// Timestamp getter
-        std::chrono::time_point<std::chrono::system_clock> getTimestamp() const;
+        std::chrono::sys_time<std::chrono::nanoseconds> getTimestamp() const;
 
         /// Fields getter
         std::string getFields() const;
@@ -86,7 +86,7 @@ namespace influxdb
         std::string mMeasurement;
 
         /// A timestamp
-        std::chrono::time_point<std::chrono::system_clock> mTimestamp;
+        std::chrono::sys_time<std::chrono::nanoseconds> mTimestamp;
 
         //// Tags
         TagSet mTags;

--- a/src/BoostSupport.cxx
+++ b/src/BoostSupport.cxx
@@ -35,10 +35,10 @@ namespace influxdb::internal
 {
     namespace
     {
-        std::chrono::system_clock::time_point parseTimeStamp(const std::string& value)
+        std::chrono::sys_time<std::chrono::nanoseconds> parseTimeStamp(const std::string& value)
         {
             std::istringstream timeString{value};
-            std::chrono::system_clock::time_point timeStamp;
+            date::sys_time<std::chrono::nanoseconds> timeStamp{};
             timeString >> date::parse("%FT%T%Z", timeStamp);
             return timeStamp;
         }

--- a/src/LineProtocol.cxx
+++ b/src/LineProtocol.cxx
@@ -127,12 +127,12 @@ namespace influxdb
         }
 
         template <class TimeUnit>
-        std::string toPrecision(std::chrono::time_point<std::chrono::system_clock> timestamp)
+        std::string toPrecision(std::chrono::sys_time<std::chrono::nanoseconds> timestamp)
         {
             return std::to_string(std::chrono::duration_cast<TimeUnit>(timestamp.time_since_epoch()).count());
         }
 
-        std::string toTimestampString(TimePrecision precision, std::chrono::time_point<std::chrono::system_clock> timestamp)
+        std::string toTimestampString(TimePrecision precision, std::chrono::sys_time<std::chrono::nanoseconds> timestamp)
         {
             switch (precision)
             {

--- a/src/Point.cxx
+++ b/src/Point.cxx
@@ -70,7 +70,7 @@ namespace influxdb
         return std::move(*this);
     }
 
-    Point&& Point::setTimestamp(std::chrono::time_point<std::chrono::system_clock> timestamp)
+    Point&& Point::setTimestamp(std::chrono::sys_time<std::chrono::nanoseconds> timestamp)
     {
         mTimestamp = timestamp;
         return std::move(*this);
@@ -81,7 +81,7 @@ namespace influxdb
         return mMeasurement;
     }
 
-    std::chrono::time_point<std::chrono::system_clock> Point::getTimestamp() const
+    std::chrono::sys_time<std::chrono::nanoseconds> Point::getTimestamp() const
     {
         return mTimestamp;
     }

--- a/test/BoostSupportTest.cxx
+++ b/test/BoostSupportTest.cxx
@@ -26,8 +26,6 @@
 #include <boost/property_tree/exceptions.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/trompeloeil.hpp>
-#include <date/date.h>
-#include <sstream>
 
 namespace influxdb::test
 {
@@ -110,10 +108,6 @@ namespace influxdb::test
     {
         using trompeloeil::_;
 
-        std::istringstream in{"2021-01-01T00:11:22.123456789Z"};
-        std::chrono::system_clock::time_point expectedTimeStamp{};
-        in >> date::parse("%FT%T%Z", expectedTimeStamp);
-
         TransportMock transport;
         ALLOW_CALL(transport, query(_))
             .RETURN(R"({"results":[{"statement_id":0,)"
@@ -124,7 +118,7 @@ namespace influxdb::test
         CHECK(result.size() == 1);
         const auto point = result[0];
         CHECK(point.getName() == "unittest");
-        CHECK(point.getTimestamp() == expectedTimeStamp);
+        CHECK(std::format("{:%FT%T}Z", point.getTimestamp()) == "2021-01-01T00:11:22.123456789Z");
         CHECK(point.getTags() == "host=localhost");
         CHECK(point.getFields() == "value=112233.000000000000000000");
     }
@@ -137,7 +131,7 @@ namespace influxdb::test
         ALLOW_CALL(transport, query(_))
             .RETURN(R"({"results":[{"statement_id":0,)"
                     R"("series":[{"name":"unittest","columns":["time","host","value"],)"
-                    R"("values":[["2021-01-01:11:22.000000000Z","host-0",100],)"
+                    R"("values":[["2021-01-01T00:11:22.000000000Z","host-0",100],)"
                     R"(["2021-01-01T00:11:23.560000000Z","host-1",30],)"
                     R"(["2021-01-01T00:11:24.780000000Z","host-2",54]]}]}]})");
 
@@ -172,7 +166,7 @@ namespace influxdb::test
         TransportMock transport;
         ALLOW_CALL(transport, query(_))
             .RETURN(R"({"results":[{"statement_id":0,"series":[{"columns":["time","host","value"],)"
-                    R"("values":[["2021-01-01:11:22.000000000Z","x",8]]}]}]})");
+                    R"("values":[["2021-01-01T00:11:22.000000000Z","x",8]]}]}]})");
 
         const auto result = internal::queryImpl(&transport, "SELECT * from test");
         CHECK(result.size() == 1);
@@ -187,7 +181,7 @@ namespace influxdb::test
         TransportMock transport;
         ALLOW_CALL(transport, query(_))
             .RETURN(R"({"results":[{"statement_id":0,"series":[{"name":"x","tags":{"type":"sp"},"columns":["time","value"],)"
-                    R"("values":[["2022-01-01:01:02.000000000ZZ",99]]}]}]})");
+                    R"("values":[["2022-01-01T00:01:02.000000000Z",99]]}]}]})");
 
         const auto result = internal::queryImpl(&transport, "SELECT * from test");
         CHECK(result.size() == 1);


### PR DESCRIPTION
Use a defined nanosecond precision for timestamps internally. There's a difference between GCC and Clang implementations.

Ensures consistent behaviour across platforms.